### PR TITLE
Deduplicate stroke input snapshots

### DIFF
--- a/src/StrokeManager.java
+++ b/src/StrokeManager.java
@@ -5,6 +5,7 @@ import java.io.*;
 import javax.swing.*;
 import java.awt.*;
 import java.nio.file.Files;
+import java.security.MessageDigest;
 import java.util.concurrent.*;
 
 public class StrokeManager {
@@ -488,6 +489,17 @@ public class StrokeManager {
         // Generate and save JSON instructions
         String instructionsPath = strokeDir.getPath() + "/" + strokeId + "_instructions.json";
         JSONObject instructions = stroke.generateJSON(projectId, app.getHardwareManager().snapshotForStroke());
+
+        JSONObject strokeInput = instructions.getJSONObject("stroke_input");
+        if (app.getCurrentImage() != null) {
+            String inputPath = saveSharedInputSnapshot(projectDir, projectId, app.getCurrentImage());
+            strokeInput.setString("input_location", inputPath);
+        }
+        strokeInput.setString(
+            "output_location",
+            normalizeRelativePath(strokeDir.getPath() + "/" + strokeId + "_output.png")
+        );
+        instructions.setJSONObject("stroke_input", strokeInput);
         app.saveJSONObject(instructions, instructionsPath);
 
         // DEBUG: Show the final JSON that was saved
@@ -505,28 +517,60 @@ public class StrokeManager {
             DebugLogger.log("  No user_input section found in JSON!");
         }
         DebugLogger.log("=== END FINAL SAVED JSON DEBUG ===\n");
-        
-        // Save input image
-        if (app.getCurrentImage() != null) {
-            String inputPath = strokeDir.getPath() + "/" + strokeId + "_input.png";
-            app.getCurrentImage().save(inputPath);
-            
-            // Update JSON with image paths
-            instructions = app.loadJSONObject(instructionsPath);
-            JSONObject strokeInput = instructions.getJSONObject("stroke_input");
-            strokeInput.setString("input_location", inputPath);
-            strokeInput.setString(
-            "output_location", 
-            strokeDir.getPath() + "/" + strokeId + "_output.png"
-            );
-            instructions.setJSONObject("stroke_input", strokeInput);
-            app.saveJSONObject(instructions, instructionsPath);
-        }
-        
         // Set current stroke index
         currentStrokeIndex = strokes.size() - 1;
         
         return strokeId;
+    }
+
+    private String saveSharedInputSnapshot(File projectDir, String projectId, PImage image) {
+        File inputDir = new File(projectDir, "input");
+        if (!inputDir.exists()) {
+            inputDir.mkdirs();
+        }
+
+        String imageHash = hashImagePixels(image);
+        String relativePath = "project/" + projectId + "/input/" + imageHash + ".png";
+        File snapshotFile = new File(inputDir, imageHash + ".png");
+        if (!snapshotFile.exists()) {
+            image.save(snapshotFile.getPath());
+            DebugLogger.log("Saved shared stroke input snapshot: " + relativePath);
+        } else {
+            DebugLogger.log("Reusing shared stroke input snapshot: " + relativePath);
+        }
+        return relativePath;
+    }
+
+    private String hashImagePixels(PImage image) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            updateDigestWithInt(digest, image.width);
+            updateDigestWithInt(digest, image.height);
+            image.loadPixels();
+            for (int pixel : image.pixels) {
+                updateDigestWithInt(digest, pixel);
+            }
+            byte[] bytes = digest.digest();
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < 16 && i < bytes.length; i++) {
+                builder.append(String.format("%02x", bytes[i] & 0xff));
+            }
+            return builder.toString();
+        } catch (Exception e) {
+            System.err.println("Error hashing image pixels: " + e.getMessage());
+            return "snapshot_" + System.currentTimeMillis();
+        }
+    }
+
+    private void updateDigestWithInt(MessageDigest digest, int value) {
+        digest.update((byte) (value >>> 24));
+        digest.update((byte) (value >>> 16));
+        digest.update((byte) (value >>> 8));
+        digest.update((byte) value);
+    }
+
+    private String normalizeRelativePath(String path) {
+        return path.replace(File.separatorChar, '/');
     }
   
   // ✅ FIXED: Completely rewrite path loading to preserve separate strokes
@@ -1450,19 +1494,17 @@ public void runStroke(Stroke stroke) {
             // Delete stroke files
             String strokeDir = "project/" + projectId + "/stroke/";
             File instructionsFile = new File(strokeDir + strokeId + "_instructions.json");
-            File inputFile = new File(strokeDir + strokeId + "_input.png");
             File outputFile = new File(strokeDir + strokeId + "_output.png");
+            String inputLocation = getStrokeInputLocation(projectId, strokeId);
             
             boolean success = true;
             if (instructionsFile.exists()) {
                 success &= instructionsFile.delete();
             }
-            if (inputFile.exists()) {
-                success &= inputFile.delete();
-            }
             if (outputFile.exists()) {
                 success &= outputFile.delete();
             }
+            success &= deleteInputSnapshotIfUnused(projectId, strokeId, inputLocation);
             
             // Update current stroke index if needed
             if (currentStrokeIndex >= strokes.size()) {
@@ -1498,6 +1540,90 @@ public void runStroke(Stroke stroke) {
         strokes.clear();
         currentStrokeIndex = -1;
         processingStrokes.clear();
+    }
+
+    private String getStrokeInputLocation(String projectId, String strokeId) {
+        String instructionsPath = "project/" + projectId + "/stroke/" + strokeId + "_instructions.json";
+        File instructionsFile = new File(instructionsPath);
+        if (instructionsFile.exists()) {
+            try {
+                JSONObject instructions = app.loadJSONObject(instructionsPath);
+                if (instructions.hasKey("stroke_input")) {
+                    JSONObject strokeInput = instructions.getJSONObject("stroke_input");
+                    return strokeInput.getString("input_location", "");
+                }
+            } catch (Exception e) {
+                System.err.println("Error reading stroke input location: " + e.getMessage());
+            }
+        }
+        return "project/" + projectId + "/stroke/" + strokeId + "_input.png";
+    }
+
+    private boolean deleteInputSnapshotIfUnused(String projectId, String strokeId, String inputLocation) {
+        if (inputLocation == null || inputLocation.isEmpty()) {
+            return true;
+        }
+
+        File projectDir = new File("project/" + projectId);
+        File inputFile = new File(inputLocation);
+        try {
+            File canonicalProject = projectDir.getCanonicalFile();
+            File canonicalInput = inputFile.getCanonicalFile();
+            if (!isWithinDirectory(canonicalInput, canonicalProject)) {
+                return true;
+            }
+
+            File sharedInputDir = new File(projectDir, "input").getCanonicalFile();
+            if (isWithinDirectory(canonicalInput, sharedInputDir)) {
+                if (!isInputLocationReferenced(projectId, strokeId, inputLocation) && inputFile.exists()) {
+                    return inputFile.delete();
+                }
+                return true;
+            }
+
+            File legacyStrokeInput = new File("project/" + projectId + "/stroke/" + strokeId + "_input.png")
+                .getCanonicalFile();
+            if (canonicalInput.equals(legacyStrokeInput) && inputFile.exists()) {
+                return inputFile.delete();
+            }
+        } catch (Exception e) {
+            System.err.println("Error cleaning up stroke input snapshot: " + e.getMessage());
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isWithinDirectory(File file, File directory) throws IOException {
+        String filePath = file.getCanonicalPath();
+        String directoryPath = directory.getCanonicalPath();
+        return filePath.equals(directoryPath) || filePath.startsWith(directoryPath + File.separator);
+    }
+
+    private boolean isInputLocationReferenced(String projectId, String deletedStrokeId, String inputLocation) {
+        File strokeDir = new File("project/" + projectId + "/stroke");
+        File[] instructionFiles = strokeDir.listFiles((dir, name) -> name.endsWith("_instructions.json"));
+        if (instructionFiles == null) {
+            return false;
+        }
+
+        for (File file : instructionFiles) {
+            if (file.getName().equals(deletedStrokeId + "_instructions.json")) {
+                continue;
+            }
+            try {
+                JSONObject instructions = app.loadJSONObject(file.getAbsolutePath());
+                if (instructions.hasKey("stroke_input")) {
+                    JSONObject strokeInput = instructions.getJSONObject("stroke_input");
+                    String otherInput = strokeInput.getString("input_location", "");
+                    if (inputLocation.equals(otherInput)) {
+                        return true;
+                    }
+                }
+            } catch (Exception e) {
+                System.err.println("Error checking input snapshot reference: " + e.getMessage());
+            }
+        }
+        return false;
     }
     
     /**
@@ -1545,8 +1671,31 @@ public void runStroke(Stroke stroke) {
 
                 // Regenerate and save the JSON (re-snapshotting current hardware config)
                 String projectId = app.getProjectId();
-                JSONObject instructions = strokeToUpdate.generateJSON(projectId, app.getHardwareManager().snapshotForStroke());
                 String instructionsPath = "project/" + projectId + "/stroke/" + strokeId + "_instructions.json";
+                JSONObject previousInput = null;
+                File instructionsFile = new File(instructionsPath);
+                if (instructionsFile.exists()) {
+                    JSONObject previousInstructions = app.loadJSONObject(instructionsPath);
+                    if (previousInstructions.hasKey("stroke_input")) {
+                        previousInput = previousInstructions.getJSONObject("stroke_input");
+                    }
+                }
+                JSONObject instructions = strokeToUpdate.generateJSON(projectId, app.getHardwareManager().snapshotForStroke());
+                JSONObject strokeInput = instructions.getJSONObject("stroke_input");
+                String defaultOutputPath = "project/" + projectId + "/stroke/" + strokeId + "_output.png";
+                if (previousInput != null) {
+                    String previousInputPath = previousInput.getString("input_location", "");
+                    if (!previousInputPath.isEmpty()) {
+                        strokeInput.setString("input_location", previousInputPath);
+                    }
+                    strokeInput.setString(
+                        "output_location",
+                        previousInput.getString("output_location", defaultOutputPath)
+                    );
+                } else {
+                    strokeInput.setString("output_location", defaultOutputPath);
+                }
+                instructions.setJSONObject("stroke_input", strokeInput);
                 
                 // Mark the stroke as pending again, as its parameters have changed.
                 // This is important so it can be re-run.

--- a/src/UIManager.java
+++ b/src/UIManager.java
@@ -572,11 +572,11 @@ public class UIManager {
         String projectId = app.getProjectId();
         if (projectId != null) {
             // Input Image
-            String inputPath = "project/" + projectId + "/stroke/" + stroke.getId() + "_input.png";
+            String inputPath = getStrokeImagePath(projectId, stroke, "input_location", "_input.png");
             addImageWithOverlay(imagesPanel, inputPath, "Input", stroke);
 
             // Output Image
-            String outputPath = "project/" + projectId + "/stroke/" + stroke.getId() + "_output.png";
+            String outputPath = getStrokeImagePath(projectId, stroke, "output_location", "_output.png");
             addImageWithOverlay(imagesPanel, outputPath, "Output", null);
         }
         detailsPanel.add(imagesPanel);
@@ -619,6 +619,34 @@ public class UIManager {
         detailsPanel.add(Box.createVerticalGlue());
         detailsPanel.revalidate();
         detailsPanel.repaint();
+    }
+
+    private String getStrokeImagePath(
+        String projectId,
+        StrokeManager.Stroke stroke,
+        String jsonKey,
+        String fallbackSuffix
+    ) {
+        String fallback = "project/" + projectId + "/stroke/" + stroke.getId() + fallbackSuffix;
+        String instructionsPath = "project/" + projectId + "/stroke/" + stroke.getId() + "_instructions.json";
+        java.io.File instructionsFile = new java.io.File(instructionsPath);
+        if (!instructionsFile.exists()) {
+            return fallback;
+        }
+
+        try {
+            JSONObject instructions = app.loadJSONObject(instructionsPath);
+            if (instructions.hasKey("stroke_input")) {
+                JSONObject strokeInput = instructions.getJSONObject("stroke_input");
+                String configuredPath = strokeInput.getString(jsonKey, "");
+                if (configuredPath != null && !configuredPath.trim().isEmpty()) {
+                    return configuredPath;
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("Error reading stroke image path: " + e.getMessage());
+        }
+        return fallback;
     }
 
     private void addImageWithOverlay(JPanel container, String imagePath, String title, StrokeManager.Stroke stroke) {


### PR DESCRIPTION
Closes #47.

## Summary
- store stroke input images in a shared project-level `input/` directory keyed by a hash of the canvas pixels
- reuse an existing snapshot when multiple strokes are created from the same canvas state instead of writing another full-size PNG per stroke
- keep the existing JSON bridge intact by continuing to populate `stroke_input.input_location` and `stroke_input.output_location`
- update Stroke Manager previews and deletion cleanup to respect the serialized image paths

## Validation
- `javac -cp lib/core-4.4.1.jar -d %TEMP%\quantumbrush-serialization-compile-check src\*.java`

## AI assistance disclosure
I used AI assistance to inspect the Java/Python serialization path and draft this patch, then reviewed the diff and validated the Java compile before submitting.
