### PR TITLE
Add Quantum Carpet particle-in-a-box brush

### DIFF
--- a/effect/quantumcarpet/README.md
+++ b/effect/quantumcarpet/README.md
@@ -4,8 +4,7 @@ Quantum Carpet paints the interference pattern of a quantum particle confined
 to a one-dimensional box. The transverse direction across the brush is the
 particle's position, while progress along the stroke acts as time.
 
-![Input example](example_before.png)
-![Quantum Carpet output](example_after.png)
+![Quantum Carpet before and after](https://github.com/user-attachments/assets/c95217d1-f798-4782-99e9-222d39506cf5)
 
 ## Quantum background
 

--- a/effect/quantumcarpet/README.md
+++ b/effect/quantumcarpet/README.md
@@ -1,0 +1,45 @@
+# Quantum Carpet
+
+Quantum Carpet paints the interference pattern of a quantum particle confined
+to a one-dimensional box. The transverse direction across the brush is the
+particle's position, while progress along the stroke acts as time.
+
+![Input example](example_before.png)
+![Quantum Carpet output](example_after.png)
+
+## Quantum background
+
+A particle in a box has stationary wave functions
+`sin(n * pi * x)` and energy levels proportional to `n^2`. Quantum Carpet
+starts with a localized wave packet made from several of these eigenstates.
+As the stroke advances, every mode accumulates phase at its own `n^2` rate.
+Their constructive and destructive interference produces the bright bands,
+dark canals, and partial revivals known as a quantum carpet.
+
+This is a deterministic wave simulation rather than a random texture. Drawing
+the same path with the same settings reproduces the same interference pattern.
+
+## Controls
+
+- **Radius** sets the width of the particle-in-a-box ribbon.
+- **Modes** sets how many energy eigenstates form the wave packet. More modes
+  create finer interference structure.
+- **Evolution** sets how quickly phase evolves along the stroke.
+- **Strength** controls the blend between the canvas and the interference.
+- **Color** selects the color revealed by high probability density.
+
+Long, gently curving strokes show the revival structure most clearly. A higher
+Evolution value fits more quantum evolution into the same physical stroke.
+
+## Validation
+
+From the repository root:
+
+```bash
+python -m unittest effect.quantumcarpet.test_quantumcarpet
+python -m effect.quantumcarpet.generate_examples
+```
+
+The implementation depends only on NumPy. AI assistance was used for repository
+navigation, implementation drafting, and test review; the result was manually
+reviewed and locally verified.

--- a/effect/quantumcarpet/__init__.py
+++ b/effect/quantumcarpet/__init__.py
@@ -1,0 +1,1 @@
+"""Quantum Carpet brush."""

--- a/effect/quantumcarpet/generate_examples.py
+++ b/effect/quantumcarpet/generate_examples.py
@@ -1,0 +1,44 @@
+"""Generate the README example images using the actual brush implementation."""
+
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+from effect.quantumcarpet.quantumcarpet import run
+
+
+def main():
+    height, width = 220, 420
+    y, x = np.mgrid[:height, :width]
+    background = np.empty((height, width, 4), dtype=np.uint8)
+    background[..., 0] = 18 + (44 * x / width).astype(np.uint8)
+    background[..., 1] = 20 + (30 * y / height).astype(np.uint8)
+    background[..., 2] = 42 + (58 * x / width).astype(np.uint8)
+    background[..., 3] = 255
+
+    path_x = np.arange(35, width - 35)
+    path_y = (height / 2 + 40 * np.sin(path_x / 58)).astype(np.int64)
+    path = np.column_stack((path_y, path_x))
+    params = {
+        "stroke_input": {
+            "image_rgba": background,
+            "path": path,
+            "clicks": path[[0]],
+        },
+        "user_input": {
+            "Radius": 42,
+            "Modes": 8,
+            "Evolution": 1.45,
+            "Strength": 0.95,
+            "Color": np.array([67, 217, 255]),
+        },
+    }
+
+    output_dir = Path(__file__).parent
+    Image.fromarray(background).save(output_dir / "example_before.png")
+    Image.fromarray(run(params)).save(output_dir / "example_after.png")
+
+
+if __name__ == "__main__":
+    main()

--- a/effect/quantumcarpet/quantumcarpet.py
+++ b/effect/quantumcarpet/quantumcarpet.py
@@ -1,0 +1,141 @@
+"""Paint particle-in-a-box interference patterns along a stroke."""
+
+import numpy as np
+
+
+def quantum_carpet_density(position, time, modes, evolution):
+    """Return normalized particle-in-a-box probability densities.
+
+    ``position`` and ``time`` are arrays in the interval [0, 1].  The brush
+    starts from a localized wave packet represented by a weighted sum of box
+    eigenstates, then evolves each mode with its characteristic n-squared
+    phase.
+    """
+
+    position = np.asarray(position, dtype=np.float64)
+    time = np.asarray(time, dtype=np.float64)
+    mode_numbers = np.arange(1, modes + 1, dtype=np.float64)
+    weights = np.exp(-0.32 * (mode_numbers - 1))
+
+    spatial_modes = np.sin(np.pi * position[..., None] * mode_numbers)
+    phases = np.exp(
+        -2j
+        * np.pi
+        * evolution
+        * time[..., None]
+        * mode_numbers**2
+    )
+    amplitude = np.sum(weights * spatial_modes * phases, axis=-1)
+    density = np.abs(amplitude) ** 2
+    return density / np.sum(weights) ** 2
+
+
+def _deduplicate_path(path):
+    path = np.asarray(path, dtype=np.int64)
+    if path.ndim != 2 or path.shape[1] != 2 or len(path) == 0:
+        raise ValueError("Stroke path must be a non-empty array of (y, x) points")
+    if len(path) == 1:
+        return path
+    keep = np.concatenate(([True], np.any(path[1:] != path[:-1], axis=1)))
+    return path[keep]
+
+
+def _stroke_region(path, radius, image_shape, chunk_size=4096):
+    """Map pixels near a stroke to signed transverse position and path time."""
+
+    height, width = image_shape
+    minimum = np.maximum(path.min(axis=0) - radius, (0, 0))
+    maximum = np.minimum(path.max(axis=0) + radius, (height - 1, width - 1))
+
+    ys = np.arange(minimum[0], maximum[0] + 1)
+    xs = np.arange(minimum[1], maximum[1] + 1)
+    grid_y, grid_x = np.meshgrid(ys, xs, indexing="ij")
+    candidates = np.column_stack((grid_y.ravel(), grid_x.ravel()))
+
+    tangents = np.empty_like(path, dtype=np.float64)
+    if len(path) == 1:
+        tangents[0] = (0.0, 1.0)
+    else:
+        tangents[0] = path[1] - path[0]
+        tangents[-1] = path[-1] - path[-2]
+        if len(path) > 2:
+            tangents[1:-1] = path[2:] - path[:-2]
+    lengths = np.linalg.norm(tangents, axis=1, keepdims=True)
+    tangents = tangents / np.maximum(lengths, 1.0)
+    normals = np.column_stack((-tangents[:, 1], tangents[:, 0]))
+
+    selected = []
+    transverse = []
+    times = []
+    for start in range(0, len(candidates), chunk_size):
+        points = candidates[start : start + chunk_size]
+        offsets = points[:, None, :] - path[None, :, :]
+        squared_distances = np.sum(offsets**2, axis=2)
+        nearest = np.argmin(squared_distances, axis=1)
+        nearest_distance = np.sqrt(squared_distances[np.arange(len(points)), nearest])
+        inside = nearest_distance <= radius
+        if not np.any(inside):
+            continue
+
+        inside_points = points[inside]
+        inside_nearest = nearest[inside]
+        inside_offsets = inside_points - path[inside_nearest]
+        signed_distance = np.sum(inside_offsets * normals[inside_nearest], axis=1)
+
+        selected.append(inside_points)
+        transverse.append(np.clip(0.5 + signed_distance / (2 * radius), 0.0, 1.0))
+        times.append(inside_nearest / max(len(path) - 1, 1))
+
+    if not selected:
+        return (
+            np.empty((0, 2), dtype=np.int64),
+            np.empty(0, dtype=np.float64),
+            np.empty(0, dtype=np.float64),
+        )
+    return np.vstack(selected), np.concatenate(transverse), np.concatenate(times)
+
+
+def run(params):
+    """Apply the Quantum Carpet effect and return an RGBA uint8 image."""
+
+    image = np.asarray(params["stroke_input"]["image_rgba"])
+    if image.ndim != 3 or image.shape[-1] != 4:
+        raise ValueError("Image must be RGBA format")
+    if image.dtype != np.uint8:
+        raise ValueError("Image must use uint8 channels")
+
+    radius = int(params["user_input"]["Radius"])
+    modes = int(params["user_input"]["Modes"])
+    evolution = float(params["user_input"]["Evolution"])
+    strength = float(params["user_input"]["Strength"])
+    color = np.asarray(params["user_input"]["Color"], dtype=np.float64)
+
+    if radius <= 0:
+        raise ValueError("Radius must be greater than zero")
+    if not 2 <= modes <= 16:
+        raise ValueError("Modes must be between 2 and 16")
+    if evolution <= 0:
+        raise ValueError("Evolution must be greater than zero")
+    if not 0 <= strength <= 1:
+        raise ValueError("Strength must be between zero and one")
+    if color.shape != (3,) or np.any((color < 0) | (color > 255)):
+        raise ValueError("Color must contain three channels between 0 and 255")
+
+    path = _deduplicate_path(params["stroke_input"]["path"])
+    coordinates, position, time = _stroke_region(path, radius, image.shape[:2])
+    output = image.copy()
+    if len(coordinates) == 0:
+        return output
+
+    density = quantum_carpet_density(position, time, modes, evolution)
+    density /= max(float(np.max(density)), np.finfo(np.float64).eps)
+    blend = (strength * np.sqrt(density))[..., None]
+
+    y, x = coordinates.T
+    original = output[y, x, :3].astype(np.float64)
+    output[y, x, :3] = np.clip(
+        original * (1.0 - blend) + color * blend,
+        0,
+        255,
+    ).astype(np.uint8)
+    return output

--- a/effect/quantumcarpet/quantumcarpet_requirements.json
+++ b/effect/quantumcarpet/quantumcarpet_requirements.json
@@ -1,0 +1,48 @@
+{
+    "name": "Quantum Carpet",
+    "id": "quantumcarpet",
+    "author": "Ryan Lin",
+    "version": "1.0.0",
+    "description": "Paint a particle-in-a-box quantum carpet along the stroke. Interference between energy eigenstates creates bands, canals, and revival structures that evolve as the stroke advances.\n\nRadius controls the ribbon width. Modes controls the complexity of the superposition. Evolution controls how quickly the quantum state changes along the stroke. Strength blends the selected color with the canvas.",
+    "dependencies": {
+        "numpy": ">=2.1.0"
+    },
+    "user_input": {
+        "Radius": {
+            "type": "int",
+            "min": 4,
+            "max": 100,
+            "default": 28
+        },
+        "Modes": {
+            "type": "int",
+            "min": 2,
+            "max": 16,
+            "default": 7
+        },
+        "Evolution": {
+            "type": "float",
+            "min": 0.1,
+            "max": 4.0,
+            "default": 1.25
+        },
+        "Strength": {
+            "type": "float",
+            "min": 0.0,
+            "max": 1.0,
+            "default": 0.85
+        },
+        "Color": {
+            "type": "color",
+            "default": "#43D9FF"
+        }
+    },
+    "stroke_input": {
+        "image_rgba": "array",
+        "path": "array",
+        "clicks": "array"
+    },
+    "flags": {
+        "smooth_path": true
+    }
+}

--- a/effect/quantumcarpet/test_quantumcarpet.py
+++ b/effect/quantumcarpet/test_quantumcarpet.py
@@ -1,0 +1,58 @@
+import unittest
+
+import numpy as np
+
+from effect.quantumcarpet.quantumcarpet import quantum_carpet_density, run
+
+
+class QuantumCarpetTest(unittest.TestCase):
+    def test_density_is_finite_and_zero_at_box_boundaries(self):
+        position = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
+        density = quantum_carpet_density(position, np.full(5, 0.4), 6, 1.25)
+
+        self.assertTrue(np.all(np.isfinite(density)))
+        self.assertTrue(np.all(density >= 0))
+        self.assertAlmostEqual(float(density[0]), 0.0, places=12)
+        self.assertAlmostEqual(float(density[-1]), 0.0, places=12)
+
+    def test_run_changes_ribbon_and_preserves_alpha_and_input(self):
+        image = np.full((48, 64, 4), (24, 32, 48, 177), dtype=np.uint8)
+        original = image.copy()
+        path = np.column_stack((np.full(40, 24), np.arange(12, 52)))
+        params = {
+            "stroke_input": {"image_rgba": image, "path": path, "clicks": path[[0]]},
+            "user_input": {
+                "Radius": 8,
+                "Modes": 7,
+                "Evolution": 1.25,
+                "Strength": 0.9,
+                "Color": np.array([67, 217, 255]),
+            },
+        }
+
+        output = run(params)
+
+        np.testing.assert_array_equal(image, original)
+        np.testing.assert_array_equal(output[..., 3], original[..., 3])
+        self.assertGreater(np.count_nonzero(output[..., :3] != original[..., :3]), 0)
+        np.testing.assert_array_equal(output[0, 0], original[0, 0])
+
+    def test_run_is_deterministic(self):
+        image = np.full((32, 32, 4), 255, dtype=np.uint8)
+        path = np.column_stack((np.arange(6, 26), np.arange(6, 26)))
+        params = {
+            "stroke_input": {"image_rgba": image, "path": path, "clicks": path[[0]]},
+            "user_input": {
+                "Radius": 5,
+                "Modes": 5,
+                "Evolution": 0.75,
+                "Strength": 1.0,
+                "Color": np.array([20, 100, 240]),
+            },
+        }
+
+        np.testing.assert_array_equal(run(params), run(params))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Example

<img width="852" height="254" alt="Quantum Carpet before and after" src="https://github.com/user-attachments/assets/c95217d1-f798-4782-99e9-222d39506cf5" />

## Summary

- add a deterministic `quantumcarpet` brush based on particle-in-a-box wave-packet evolution
- map transverse position across the stroke to the particle position and progress along the stroke to time
- expose controls for ribbon radius, eigenstate modes, evolution rate, blend strength, and color
- include a physics/creative-use README, generated before/after images, and focused unit tests

The brush uses interference between energy eigenstates with their characteristic
`n^2` phase evolution, producing bright bands, dark canals, and partial revival
structures along a stroke. It depends only on NumPy at runtime.

## Validation

- `python -m unittest effect.quantumcarpet.test_quantumcarpet -v`
  - 3 tests passed
- `python -m effect.quantumcarpet.generate_examples`
  - generated the committed before/after images from the actual brush
- `python -m py_compile effect/quantumcarpet/quantumcarpet.py effect/quantumcarpet/generate_examples.py effect/quantumcarpet/test_quantumcarpet.py`
- validated `effect/quantumcarpet/quantumcarpet_requirements.json` as JSON

## AI disclosure

I used OpenAI Codex for repository navigation, implementation drafting, test
review, and submission preparation. I reviewed the implementation, inspected
the generated output, and ran the validation commands above locally.

Addresses #50.
