### PR TITLE
Add release installer packaging workflow

### DIFF
--- a/.github/workflows/package-installers.yml
+++ b/.github/workflows/package-installers.yml
@@ -1,0 +1,29 @@
+name: Package installers
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  package:
+    name: Build installer artifacts
+    runs-on: macos-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Build installer artifacts
+        env:
+          QUANTUMBRUSH_VERSION: ${{ github.ref_name }}
+          MACOS_CODESIGN_IDENTITY: ${{ secrets.MACOS_CODESIGN_IDENTITY }}
+        run: |
+          chmod +x packaging/build-installers.sh
+          packaging/build-installers.sh
+
+      - name: Upload installer artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: quantumbrush-installers
+          path: dist-installers/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
 .DS_Store
+._*
 install.sh
 .code-workspace
 test.ipynb
 **/__pycache__/
 __pycache__/
 config/
+dist-installers/
 log/
 metadata/
 project/

--- a/README.md
+++ b/README.md
@@ -75,6 +75,39 @@ To update you will need to run a similar process, but this time using the `updat
 1. Open a terminal, as in step 2 above.
 2. Write `sh ~/QuantumBrush/update.sh` (or copy-paste from here) and then press Enter to run the update script.
 
+## Release packaging
+
+Maintainers can build user-facing installer artifacts from this branch without
+asking artists to download `setup.sh` from the Releases page first:
+
+```bash
+chmod +x packaging/build-installers.sh
+QUANTUMBRUSH_VERSION=v0.0.3 packaging/build-installers.sh
+```
+
+The packaging script writes artifacts to `dist-installers/`:
+
+- `QuantumBrush-<version>-macos.dmg` on macOS. The DMG contains a
+  `QuantumBrush.app` wrapper. On first launch it copies the release payload into
+  `$HOME/QuantumBrush` and opens the setup flow for Java/Miniconda/Python
+  dependencies. Later launches run `QuantumBrush.jar` directly.
+- `QuantumBrush-<version>-windows-portable.zip`, which contains the app payload
+  and a `QuantumBrush.bat` launcher for Git Bash/Windows environments.
+- `QuantumBrush-<version>-linux.tar.gz`, which contains the app payload and a
+  `quantumbrush` launcher.
+
+The GitHub Actions workflow in `.github/workflows/package-installers.yml`
+builds the same artifacts on tags and manual dispatches, then uploads them as
+release-ready artifacts.
+
+macOS signing is intentionally wired as a maintainer-owned hook. If the
+repository has a valid Developer ID certificate available on the runner, set the
+`MACOS_CODESIGN_IDENTITY` secret and the workflow will sign the app bundle before
+creating the DMG. Without that secret, the workflow still produces unsigned
+artifacts for testing, but maintainers should sign and notarize public releases.
+Set `QUANTUMBRUSH_OUT_DIR=/path/to/output` to build artifacts outside the
+repository, which is useful for local smoke tests.
+
 # Examples
 
 The combination of the stroke and the quantum brush that we choose, the result is this!

--- a/packaging/build-installers.sh
+++ b/packaging/build-installers.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+OUT_DIR="${QUANTUMBRUSH_OUT_DIR:-${ROOT_DIR}/dist-installers}"
+STAGE_DIR="${OUT_DIR}/stage"
+export COPYFILE_DISABLE=1
+
+APP_NAME="QuantumBrush"
+VERSION="${QUANTUMBRUSH_VERSION:-local}"
+
+rm -rf "$OUT_DIR"
+mkdir -p "$STAGE_DIR"
+
+copy_payload() {
+  local dest="$1"
+  mkdir -p "$dest"
+  cp "$ROOT_DIR/QuantumBrush.jar" "$dest/"
+  cp -R "$ROOT_DIR/QuantumBrush_lib" "$dest/"
+  cp -R "$ROOT_DIR/effect" "$dest/"
+  cp "$ROOT_DIR/setup.sh" "$ROOT_DIR/update.sh" "$ROOT_DIR/Setup.command" "$ROOT_DIR/Update.command" "$dest/"
+  cp "$ROOT_DIR/README.md" "$ROOT_DIR/LICENSE-2.0.txt" "$dest/"
+}
+
+build_macos_app() {
+  local app_dir="$STAGE_DIR/macos/${APP_NAME}.app"
+  mkdir -p "$app_dir/Contents/MacOS" "$app_dir/Contents/Resources"
+  copy_payload "$app_dir/Contents/Resources/QuantumBrush"
+  cp "$ROOT_DIR/packaging/macos/QuantumBrush" "$app_dir/Contents/MacOS/QuantumBrush"
+  chmod +x "$app_dir/Contents/MacOS/QuantumBrush"
+  cat > "$app_dir/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key>
+  <string>QuantumBrush</string>
+  <key>CFBundleIdentifier</key>
+  <string>org.mothquantum.quantumbrush</string>
+  <key>CFBundleName</key>
+  <string>QuantumBrush</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>${VERSION}</string>
+</dict>
+</plist>
+PLIST
+
+  if [ -n "${MACOS_CODESIGN_IDENTITY:-}" ]; then
+    codesign --force --deep --timestamp --options runtime --sign "$MACOS_CODESIGN_IDENTITY" "$app_dir"
+  fi
+
+  if command -v hdiutil >/dev/null 2>&1; then
+    hdiutil create -volname "$APP_NAME" -srcfolder "$app_dir" -ov -format UDZO "$OUT_DIR/${APP_NAME}-${VERSION}-macos.dmg"
+  else
+    (cd "$STAGE_DIR/macos" && tar --no-xattrs -czf "$OUT_DIR/${APP_NAME}-${VERSION}-macos-app.tar.gz" "${APP_NAME}.app")
+  fi
+}
+
+build_windows_zip() {
+  local dest="$STAGE_DIR/windows/${APP_NAME}"
+  copy_payload "$dest"
+  cp "$ROOT_DIR/packaging/windows/QuantumBrush.bat" "$dest/"
+  (cd "$STAGE_DIR/windows" && zip -qr "$OUT_DIR/${APP_NAME}-${VERSION}-windows-portable.zip" "$APP_NAME")
+}
+
+build_linux_tarball() {
+  local dest="$STAGE_DIR/linux/${APP_NAME}"
+  copy_payload "$dest"
+  cp "$ROOT_DIR/packaging/linux/quantumbrush" "$dest/"
+  chmod +x "$dest/quantumbrush" "$dest/setup.sh" "$dest/update.sh"
+  (cd "$STAGE_DIR/linux" && tar --no-xattrs -czf "$OUT_DIR/${APP_NAME}-${VERSION}-linux.tar.gz" "$APP_NAME")
+}
+
+build_macos_app
+build_windows_zip
+build_linux_tarball
+
+rm -rf "$STAGE_DIR"
+find "$OUT_DIR" -name '._*' -type f -delete
+find "$OUT_DIR" -maxdepth 1 -type f -print | sort

--- a/packaging/linux/quantumbrush
+++ b/packaging/linux/quantumbrush
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+APP_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+INSTALL_DIR="${HOME}/QuantumBrush"
+
+if [ ! -d "$INSTALL_DIR" ]; then
+  mkdir -p "$INSTALL_DIR"
+  cp -R "$APP_DIR"/. "$INSTALL_DIR"/
+  chmod +x "$INSTALL_DIR/setup.sh" "$INSTALL_DIR/update.sh" 2>/dev/null || true
+fi
+
+if [ ! -f "$INSTALL_DIR/config/python_path.txt" ]; then
+  printf '%s\n' "QuantumBrush is not set up yet. Starting setup..."
+  cd "$INSTALL_DIR"
+  ./setup.sh
+  exit $?
+fi
+
+exec java -jar "$INSTALL_DIR/QuantumBrush.jar"

--- a/packaging/macos/QuantumBrush
+++ b/packaging/macos/QuantumBrush
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+APP_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+RESOURCES_DIR="$APP_DIR/Resources"
+INSTALL_DIR="$HOME/QuantumBrush"
+
+run_setup() {
+  osascript <<APPLESCRIPT
+tell application "Terminal"
+  activate
+  do script "cd \"${INSTALL_DIR}\" && ./setup.sh"
+end tell
+APPLESCRIPT
+}
+
+if [ ! -d "$INSTALL_DIR" ]; then
+  mkdir -p "$INSTALL_DIR"
+  cp -R "$RESOURCES_DIR/QuantumBrush"/. "$INSTALL_DIR/"
+  chmod +x "$INSTALL_DIR/setup.sh" "$INSTALL_DIR/update.sh" "$INSTALL_DIR/Setup.command" "$INSTALL_DIR/Update.command" 2>/dev/null || true
+  run_setup
+  exit 0
+fi
+
+if [ ! -f "$INSTALL_DIR/config/python_path.txt" ]; then
+  run_setup
+  exit 0
+fi
+
+exec /usr/bin/java -jar "$INSTALL_DIR/QuantumBrush.jar"

--- a/packaging/windows/QuantumBrush.bat
+++ b/packaging/windows/QuantumBrush.bat
@@ -1,0 +1,20 @@
+@echo off
+setlocal
+
+set "APP_DIR=%~dp0"
+set "INSTALL_DIR=%USERPROFILE%\QuantumBrush"
+
+if not exist "%INSTALL_DIR%" (
+  mkdir "%INSTALL_DIR%" >nul 2>nul
+  xcopy "%APP_DIR%*" "%INSTALL_DIR%\" /E /I /Y >nul
+)
+
+if not exist "%INSTALL_DIR%\config\python_path.txt" (
+  echo QuantumBrush is not set up yet. Starting setup...
+  pushd "%INSTALL_DIR%"
+  bash setup.sh
+  popd
+  exit /b %ERRORLEVEL%
+)
+
+java -jar "%INSTALL_DIR%\QuantumBrush.jar"


### PR DESCRIPTION
## Summary

This PR adds release packaging support for QuantumBrush so artists do not have to start from a raw `setup.sh` download as the main installation experience.

It adds:

- a macOS `QuantumBrush.app` wrapper and DMG build path
- a Windows portable zip with a `QuantumBrush.bat` launcher
- a Linux tarball with a `quantumbrush` launcher
- a GitHub Actions workflow for tag/manual packaging runs
- a maintainer-owned macOS signing hook via `MACOS_CODESIGN_IDENTITY`
- README instructions for local packaging and CI artifact generation

The launchers preserve the existing setup behavior: first launch copies the release payload into `$HOME/QuantumBrush`, starts the existing Java/Miniconda/Python setup flow when needed, and later launches run `QuantumBrush.jar` directly.

## Validation

Ran locally on macOS:

```bash
bash -n packaging/build-installers.sh packaging/macos/QuantumBrush packaging/linux/quantumbrush setup.sh update.sh
git diff --check
QUANTUMBRUSH_VERSION=test QUANTUMBRUSH_OUT_DIR=/tmp/quantumbrush-installers-test packaging/build-installers.sh
```

Generated artifacts:

```text
/tmp/quantumbrush-installers-test/QuantumBrush-test-linux.tar.gz
/tmp/quantumbrush-installers-test/QuantumBrush-test-macos.dmg
/tmp/quantumbrush-installers-test/QuantumBrush-test-windows-portable.zip
```

Also verified:

```bash
test ! -e /tmp/quantumbrush-installers-test/stage
zipinfo -1 /tmp/quantumbrush-installers-test/QuantumBrush-test-windows-portable.zip | rg '(^|/)\._' || true
tar -tzf /tmp/quantumbrush-installers-test/QuantumBrush-test-linux.tar.gz | rg '(^|/)\._' || true
```

The archive checks produced no AppleDouble `._*` entries.

## Notes

- Public macOS releases should still be signed and notarized by maintainers with Apple Developer ID credentials. This PR wires the codesign hook but does not include private signing material.
- The Windows artifact is a portable zip launcher rather than a signed `.exe`, so a future follow-up can add NSIS/WiX/MSIX if that is preferred for the final release channel.

Fixes #49
