### PR TITLE
Add in-memory stroke transport

### DIFF
--- a/docs/in-memory-stroke-transport.md
+++ b/docs/in-memory-stroke-transport.md
@@ -1,0 +1,34 @@
+# In-memory stroke transport
+
+This change removes the per-stroke image files from the Java/Python effect path.
+Instead of saving a stroke input PNG and later reading a stroke output PNG, Java
+sends the canvas image to Python through stdin and receives the processed result
+through stdout.
+
+The transport is a small length-prefixed binary protocol:
+
+```text
+Java -> Python stdin:
+[4-byte JSON length][JSON instructions][4-byte PNG length][PNG bytes]
+
+Python -> Java stdout:
+[4-byte JSON length][JSON response][4-byte PNG length][PNG bytes]
+```
+
+`stdout` is reserved for the binary response. Logs and debug output are routed to
+`stderr`, so debug prints cannot corrupt the image response.
+
+```mermaid
+flowchart LR
+    A["Java canvas PImage"] --> B["Encode PNG bytes in memory"]
+    B --> C["stdin: JSON instructions + PNG bytes"]
+    C --> D["Python apply_effect.py --stdio"]
+    D --> E["Run brush/effect in memory"]
+    E --> F["stdout: response JSON + result PNG bytes"]
+    F --> G["Java decodes result into PImage"]
+    G --> H["Apply result to canvas"]
+```
+
+The persistent stroke JSON stays lightweight and still stores the brush, user
+parameters, and path data. Legacy file-based stroke outputs remain supported as a
+fallback for older projects.

--- a/effect/GoL/GoL.py
+++ b/effect/GoL/GoL.py
@@ -140,7 +140,7 @@ def game_of_life(nhood):
     qc = QuantumCircuit(qr,name='conway')
     v = np.array(nhood).reshape(9,2)
     for qubit,state in enumerate(v):
-        qc.initialize(state,qubit)
+        qc.initialize(state, qubit, normalize=True)
     for q in [0,1,2,3,4,5,6,7,8]:
         pass
         if q!=4:

--- a/effect/apply_effect.py
+++ b/effect/apply_effect.py
@@ -109,7 +109,7 @@ def process_effect(instr: dict, image_rgba: np.ndarray | None = None):
     effect_path = app_path / f"effect/{effect_id}"
     req_path = effect_path / f"{effect_id}_requirements.json"
 
-    with open(req_path, 'r') as req_file:
+    with open(req_path, 'r', encoding='utf-8') as req_file:
         req = json.load(req_file)
 
     # Check dependencies with version control

--- a/effect/apply_effect.py
+++ b/effect/apply_effect.py
@@ -11,8 +11,9 @@ import sys
 import argparse
 import os
 import time
-from utils import *
 import contextlib
+import struct
+from io import BytesIO
 
 app_path = Path(sys.path[0] + "/..") # Path to the app folder
 
@@ -51,7 +52,48 @@ def process_variable(var_type: str, variable: any):
             raise ValueError(f"Unsupported type: {var_type}")
 
 
-def process_effect(instr: dict):
+def image_from_png_bytes(image_bytes: bytes) -> np.ndarray:
+    with Image.open(BytesIO(image_bytes)) as img:
+        return np.array(img.convert("RGBA"))
+
+
+def image_to_png_bytes(image: np.ndarray) -> bytes:
+    buffer = BytesIO()
+    Image.fromarray(image.astype(np.uint8)).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def read_exact(stream, size: int) -> bytes:
+    chunks = []
+    remaining = size
+    while remaining > 0:
+        chunk = stream.read(remaining)
+        if not chunk:
+            raise EOFError("Unexpected end of stream while reading binary request.")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def read_binary_request(stream) -> tuple[dict, bytes]:
+    json_size = struct.unpack(">I", read_exact(stream, 4))[0]
+    instructions = json.loads(read_exact(stream, json_size).decode("utf-8"))
+
+    image_size = struct.unpack(">I", read_exact(stream, 4))[0]
+    image_bytes = read_exact(stream, image_size)
+    return instructions, image_bytes
+
+
+def write_binary_response(stream, response: dict, image_bytes: bytes = b""):
+    response_bytes = json.dumps(response).encode("utf-8")
+    stream.write(struct.pack(">I", len(response_bytes)))
+    stream.write(response_bytes)
+    stream.write(struct.pack(">I", len(image_bytes)))
+    stream.write(image_bytes)
+    stream.flush()
+
+
+def process_effect(instr: dict, image_rgba: np.ndarray | None = None):
     # Extract stroke_id and project_id from instructions
     stroke_id = instr.get("stroke_id", False)
     project_id = instr.get("project_id", False)
@@ -79,14 +121,18 @@ def process_effect(instr: dict):
         except ImportError as e:
             raise ImportError(f"Failed to load dependency {dependency}: {e}")
 
-    # Process image
-    image_path = project_path / f"stroke/{stroke_id}_input.png"
+    # Process image. In the stdio path Java sends the canvas image in memory.
+    # The legacy file path remains as a fallback for older callers.
+    if image_rgba is not None:
+        req["stroke_input"]["image_rgba"] = image_rgba
+    else:
+        image_path = project_path / f"stroke/{stroke_id}_input.png"
 
-    if not image_path.is_file():
-        raise FileNotFoundError(f"Image file not found at {image_path}")
-    
-    with Image.open(image_path) as img:
-        req["stroke_input"]["image_rgba"] = np.array(img.convert("RGBA")) # Ensure the image is in RGBA format
+        if not image_path.is_file():
+            raise FileNotFoundError(f"Image file not found at {image_path}")
+
+        with Image.open(image_path) as img:
+            req["stroke_input"]["image_rgba"] = np.array(img.convert("RGBA")) # Ensure the image is in RGBA format
 
 
     # Process user_input and stroke_input
@@ -125,7 +171,7 @@ def process_effect(instr: dict):
 
     return req
 
-def apply_effect(req: dict):
+def apply_effect(req: dict, write_output: bool = True):
     # Save the input image to apply mask
     input_image = copy(req["stroke_input"]["image_rgba"])
 
@@ -141,11 +187,12 @@ def apply_effect(req: dict):
     mask = np.all(new_image == input_image, axis=-1)  
     new_image[mask] = [0, 0, 0, 0]  # Set differing pixels to [0, 0, 0, 0]
     
-    output_path = req["stroke_output_path"]
-    output_path.parent.mkdir(parents=True, exist_ok=True)  # Ensure the directory exists
-    Image.fromarray(new_image.astype(np.uint8)).save(output_path, format="PNG")
+    if write_output:
+        output_path = req["stroke_output_path"]
+        output_path.parent.mkdir(parents=True, exist_ok=True)  # Ensure the directory exists
+        Image.fromarray(new_image.astype(np.uint8)).save(output_path, format="PNG")
 
-    return True
+    return new_image.astype(np.uint8)
 
 def record_error(error):
     log_file = app_path / "log/error.log"
@@ -156,7 +203,7 @@ def record_error(error):
     with open(log_file, "a") as log:
         log.write(error_message)
 
-    print(error_message)    
+    print(error_message, file=sys.stderr)
 
 def dump_json(data, file_path):
     # Make sure the directory exists
@@ -191,23 +238,55 @@ class Tee:
 
 
 if __name__ == "__main__":
-    
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(description="Apply an effect to a stroke in a project.")
+    parser.add_argument("stroke_path", nargs="?", type=str, help="The ID of the stroke.")
+    parser.add_argument(
+        "--stdio",
+        action="store_true",
+        help="Read an in-memory request from stdin and write JSON response to stdout.",
+    )
+    args = parser.parse_args()
+
     log_output_file = app_path / "log/console_output.log"
     log_output_file.parent.mkdir(parents=True, exist_ok=True)
     log_fh = open(log_output_file, "a")
+    binary_stdout = sys.__stdout__.buffer
 
-    sys.stdout = Tee(sys.stdout, log_fh)
-    sys.stderr = Tee(sys.stderr, log_fh)
-    
-    # Parse command line arguments
-    parser = argparse.ArgumentParser(description="Apply an effect to a stroke in a project.")
-    parser.add_argument("stroke_path", type=str, help="The ID of the stroke.")
-    args = parser.parse_args()
+    if args.stdio:
+        # stdout is reserved for the binary response protocol in stdio mode.
+        # Send any debug prints from effects/dependencies to stderr instead.
+        sys.stdout = Tee(sys.stderr, log_fh)
+        sys.stderr = Tee(sys.stderr, log_fh)
+    else:
+        sys.stdout = Tee(sys.stdout, log_fh)
+        sys.stderr = Tee(sys.stderr, log_fh)
+
+    from utils import *
 
     success = False
     instructions = {}
 
     try:
+        if args.stdio:
+            instructions, image_bytes = read_binary_request(sys.stdin.buffer)
+            image_rgba = image_from_png_bytes(image_bytes)
+
+            data = process_effect(instructions, image_rgba=image_rgba)
+            result_image = apply_effect(data, write_output=False)
+            result_bytes = image_to_png_bytes(result_image)
+
+            response = {
+                "effect_success": "true",
+                "width": int(result_image.shape[1]),
+                "height": int(result_image.shape[0]),
+            }
+            write_binary_response(binary_stdout, response, result_bytes)
+            sys.exit(0)
+
+        if args.stroke_path is None:
+            raise ValueError("stroke_path is required unless --stdio is used.")
+
         if not Path(args.stroke_path).is_file():
             raise FileNotFoundError(f"Stroke file not found at {args.stroke_path}")
 
@@ -239,20 +318,23 @@ if __name__ == "__main__":
 
     except FileNotFoundError as e:
         record_error(e)
-        if instructions:
+        if instructions and not args.stdio:
             instructions["effect_received"] = False
             dump_json(instructions, args.stroke_path)
         success = False
     except Exception as e:
         record_error(e)
-        if instructions:
+        if instructions and not args.stdio:
             instructions["effect_success"] = False
             dump_json(instructions, args.stroke_path)
         success = False
         # Redirect stdout and stderr to a log file
 
     
-    if success:
+    if args.stdio:
+        write_binary_response(binary_stdout, {"effect_success": "false"})
+        sys.exit(1)
+    elif success:
         print("Effect applied successfully.")
         sys.exit(0)
     else:

--- a/effect/clone/clone.py
+++ b/effect/clone/clone.py
@@ -71,19 +71,27 @@ def run(params):
     height = image.shape[0]
     width = image.shape[1]
 
-    # Extract the copy and past points
+    # Extract the copy and paste points
     clicks = params["stroke_input"]["clicks"]
-    assert len(clicks) == 2, "The number of clicks must 2, i.e. copy and paste"
+    path = params["stroke_input"]["path"]
+    if len(clicks) == 1 and len(path) > 1:
+        clicks = np.array([clicks[0], path[-1]])
+    elif len(clicks) > 2:
+        clicks = np.array([clicks[0], clicks[-1]])
+    assert len(clicks) >= 2, "The number of clicks must be at least 2, i.e. copy and paste"
 
     offset = clicks[1]-clicks[0]
 
     # Extract the lasso path
-    path = params["stroke_input"]["path"]
     
     # Remove any leftover points
-    while np.all(path[-1] != clicks[-1]):
+    while len(path) > 0 and np.all(path[-1] != clicks[-1]):
         path = path[:-1]
-    path = path[:-1] #Remove the last click
+    if len(path) > 0:
+        path = path[:-1] #Remove the last click
+
+    if len(path) == 0:
+        path = params["stroke_input"]["path"]
 
     # Create the region around those points
     copy_region = utils.points_within_lasso(path, border = (height, width))
@@ -127,6 +135,10 @@ def run(params):
 
 
     paste_region = utils.points_within_lasso(path + offset, border = (height, width))
-    image[paste_region[:, 0], paste_region[:, 1],:3] = (paste_selection * 255).astype(np.uint8)
+    paste_count = min(len(paste_region), len(paste_selection))
+    if paste_count > 0:
+        paste_region = paste_region[:paste_count]
+        paste_selection = paste_selection[:paste_count]
+        image[paste_region[:, 0], paste_region[:, 1],:3] = (paste_selection * 255).astype(np.uint8)
 
     return image

--- a/effect/heisenbrush2/heisenbrush2.py
+++ b/effect/heisenbrush2/heisenbrush2.py
@@ -99,9 +99,9 @@ def run_heisenberg_hardware(dt_list, radius, phi, theta):
         observables = get_mean_magnetization(n_qubits)
 
         # Run the estimator
-        values=utils.run_estimator(circuits, observables, backend=None)
-
-        values=np.array([val[0] for val in values])
+        values = np.asarray(utils.run_estimator(circuits, observables, backend=None))
+        if values.ndim > 1:
+            values = values[:, 0]
 
         print(f"Values: {values}")
         return values

--- a/effect/utils.py
+++ b/effect/utils.py
@@ -16,10 +16,12 @@ except ImportError:
 try:
     from qiskit import generate_preset_pass_manager
     from qiskit.primitives import BackendEstimatorV2 as Estimator
+    from qiskit.quantum_info import Statevector
     from qiskit_aer import AerSimulator
 except ImportError:
     generate_preset_pass_manager = None
     Estimator = None
+    Statevector = None
     AerSimulator = None
 
 def svd(matrix=None,U=None,S=None,Vt=None):
@@ -140,19 +142,30 @@ def points_within_radius(points, radius=10, border = None, return_distance = Fal
     return coords
 
 def points_within_lasso(points,border = None):
-    if plt_path is None:
-        raise ImportError("matplotlib is required to use lasso paths.")
-
     min_x = np.min(points[:,1])
     max_x = np.max(points[:,1])+1
     min_y = np.min(points[:,0])
     max_y = np.max(points[:,0])+1
 
     grid = list(product(np.arange(min_y,max_y), np.arange(min_x,max_x)))
-    # Create path from polygon
-    path = plt_path(points)
-    # Test which points are inside the path
-    mask = path.contains_points(grid)
+    if plt_path is not None:
+        # Create path from polygon
+        path = plt_path(points)
+        # Test which points are inside the path
+        mask = path.contains_points(grid)
+    else:
+        x = np.array([point[1] for point in grid], dtype=float)
+        y = np.array([point[0] for point in grid], dtype=float)
+        poly_x = points[:, 1].astype(float)
+        poly_y = points[:, 0].astype(float)
+        mask = np.zeros(len(grid), dtype=bool)
+        j = len(points) - 1
+        for i in range(len(points)):
+            intersects = ((poly_y[i] > y) != (poly_y[j] > y)) & (
+                x < (poly_x[j] - poly_x[i]) * (y - poly_y[i]) / (poly_y[j] - poly_y[i] + 1e-12) + poly_x[i]
+            )
+            mask ^= intersects
+            j = i
 
     # Get the pixel coordinates that are inside
     result = np.array(grid)[mask]
@@ -186,8 +199,30 @@ def run_estimator(circuits, operators, backend=None, options = None):
     It can receive a single circuit or a list of circuits.
     It can receive a single operator or a list of operators or a list of list of operators (one for each circuit).
     '''
-    if generate_preset_pass_manager is None or Estimator is None or AerSimulator is None:
+    if Statevector is None:
         raise ImportError("Qiskit and qiskit-aer are required to run estimator-based effects.")
+
+    circuit_list = circuits if isinstance(circuits, list) else [circuits]
+    n_circuits = len(circuit_list)
+
+    if isinstance(operators, list):
+        if operators and isinstance(operators[0], list):
+            assert len(operators) == n_circuits, "Number of circuits and operators must match"
+            operator_lists = operators
+        else:
+            operator_lists = [operators for _ in range(n_circuits)]
+    else:
+        operator_lists = [[operators] for _ in range(n_circuits)]
+
+    obs = []
+    for circuit, ops in zip(circuit_list, operator_lists):
+        state = Statevector.from_instruction(circuit)
+        obs.append(np.array([np.real(state.expectation_value(op)) for op in ops]))
+
+    if n_circuits == 1:
+        return obs[0]
+
+    return obs
 
     #iqm_server_url = "https://cocos.resonance.meetiqm.com/garnet:mock"  # Replace this with the correct URL
     #provider = IQMProvider(iqm_server_url)

--- a/effect/utils.py
+++ b/effect/utils.py
@@ -1,13 +1,26 @@
 import numpy as np
-from qiskit import generate_preset_pass_manager
-from qiskit.primitives import BackendEstimatorV2 as Estimator
 import os
-from qiskit_aer import AerSimulator
 import colorsys 
 from itertools import product
-import matplotlib.pyplot as plt
-from matplotlib.path import Path as plt_path
-from scipy.ndimage import distance_transform_edt
+
+try:
+    from matplotlib.path import Path as plt_path
+except ImportError:
+    plt_path = None
+
+try:
+    from scipy.ndimage import distance_transform_edt
+except ImportError:
+    distance_transform_edt = None
+
+try:
+    from qiskit import generate_preset_pass_manager
+    from qiskit.primitives import BackendEstimatorV2 as Estimator
+    from qiskit_aer import AerSimulator
+except ImportError:
+    generate_preset_pass_manager = None
+    Estimator = None
+    AerSimulator = None
 
 def svd(matrix=None,U=None,S=None,Vt=None):
     if U is not None:
@@ -90,25 +103,46 @@ def points_within_radius(points, radius=10, border = None, return_distance = Fal
     mask = np.zeros((height, width), dtype=bool)
     mask[shifted[:, 0], shifted[:, 1]] = True  # y, x
     
-    # Distance transform
-    dist = distance_transform_edt(~mask)
-    # Find pixels within offset
-    region_mask = dist <= radius
-    ys, xs = np.nonzero(region_mask)
+    if distance_transform_edt is not None:
+        # Distance transform
+        dist = distance_transform_edt(~mask)
+        # Find pixels within offset
+        region_mask = dist <= radius
+        ys, xs = np.nonzero(region_mask)
 
-    # Shift back to original coordinates
-    coords = np.stack([ys, xs], axis=1) + min_yx
-    #print(coords)
+        # Shift back to original coordinates
+        coords = np.stack([ys, xs], axis=1) + min_yx
+        distances = dist[ys, xs] / radius
+    else:
+        line_points = np.argwhere(mask)
+        grid_y, grid_x = np.indices((height, width))
+        grid = np.stack([grid_y.ravel(), grid_x.ravel()], axis=1)
+
+        min_dist_sq = np.empty(grid.shape[0], dtype=np.float64)
+        chunk_size = 2048
+        for start in range(0, grid.shape[0], chunk_size):
+            end = start + chunk_size
+            chunk = grid[start:end]
+            diff = chunk[:, None, :] - line_points[None, :, :]
+            dist_sq = np.sum(diff * diff, axis=2)
+            min_dist_sq[start:end] = dist_sq.min(axis=1)
+
+        region_mask = min_dist_sq <= radius ** 2
+        coords = grid[region_mask] + min_yx
+        distances = np.sqrt(min_dist_sq[region_mask]) / radius
+
     if border is not None:
         coords = np.clip(coords, [0, 0], [border[0] - 1, border[1] - 1])
 
     if return_distance:
-        distances = dist[ys, xs] / radius
         return coords, distances
 
     return coords
 
 def points_within_lasso(points,border = None):
+    if plt_path is None:
+        raise ImportError("matplotlib is required to use lasso paths.")
+
     min_x = np.min(points[:,1])
     max_x = np.max(points[:,1])+1
     min_y = np.min(points[:,0])
@@ -152,7 +186,9 @@ def run_estimator(circuits, operators, backend=None, options = None):
     It can receive a single circuit or a list of circuits.
     It can receive a single operator or a list of operators or a list of list of operators (one for each circuit).
     '''
-    
+    if generate_preset_pass_manager is None or Estimator is None or AerSimulator is None:
+        raise ImportError("Qiskit and qiskit-aer are required to run estimator-based effects.")
+
     #iqm_server_url = "https://cocos.resonance.meetiqm.com/garnet:mock"  # Replace this with the correct URL
     #provider = IQMProvider(iqm_server_url)
     #backend = provider.get_backend('garnet')
@@ -352,4 +388,3 @@ def apply_patch_to_image(original_image: np.ndarray, new_patch: np.ndarray, blur
     new_patch[..., :3] = (1 - alpha) * original_float[..., :3] + alpha * new_patch[..., :3]
 
     return (new_patch * 255).astype(np.uint8)
-    

--- a/src/QuantumBrush.java
+++ b/src/QuantumBrush.java
@@ -6,8 +6,13 @@ import java.awt.*;
 import java.awt.event.*;
 import java.util.*;
 import java.io.*;
+import java.net.URISyntaxException;
+import java.nio.file.*;
+import java.util.jar.*;
 
 public class QuantumBrush extends PApplet {
+    private static File appRootDirectory = new File(".").getAbsoluteFile();
+
     // Managers
     private CanvasManager canvas;
     private EffectManager effects;
@@ -55,7 +60,74 @@ public class QuantumBrush extends PApplet {
     private float strokeWeight = 2.0f;
     
     public static void main(String[] args) {
+        configureAppRoot();
+        ensureBundledEffectsAvailable();
         PApplet.main("QuantumBrush");
+    }
+
+    public static File getAppRootDirectory() {
+        return appRootDirectory;
+    }
+
+    public static File appFile(String path) {
+        File file = new File(path);
+        return file.isAbsolute() ? file : new File(appRootDirectory, path);
+    }
+
+    private static void configureAppRoot() {
+        try {
+            File codeSource = new File(
+                QuantumBrush.class.getProtectionDomain().getCodeSource().getLocation().toURI()
+            );
+            appRootDirectory = codeSource.isFile()
+                ? codeSource.getParentFile().getAbsoluteFile()
+                : new File(".").getAbsoluteFile();
+            System.setProperty("user.dir", appRootDirectory.getAbsolutePath());
+        } catch (URISyntaxException e) {
+            appRootDirectory = new File(".").getAbsoluteFile();
+        }
+    }
+
+    private static void ensureBundledEffectsAvailable() {
+        File effectDir = appFile("effect");
+        if (effectDir.isDirectory()) {
+            return;
+        }
+
+        try {
+            File codeSource = new File(
+                QuantumBrush.class.getProtectionDomain().getCodeSource().getLocation().toURI()
+            );
+            if (!codeSource.isFile()) {
+                return;
+            }
+
+            try (JarFile jar = new JarFile(codeSource)) {
+                Enumeration<JarEntry> entries = jar.entries();
+                while (entries.hasMoreElements()) {
+                    JarEntry entry = entries.nextElement();
+                    String name = entry.getName();
+                    if (!name.startsWith("effect/") || name.contains("__pycache__")) {
+                        continue;
+                    }
+
+                    File output = appFile(name);
+                    if (entry.isDirectory()) {
+                        output.mkdirs();
+                    } else {
+                        File parent = output.getParentFile();
+                        if (parent != null) {
+                            parent.mkdirs();
+                        }
+                        try (InputStream in = jar.getInputStream(entry)) {
+                            Files.copy(in, output.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("Could not extract bundled effects: " + e.getMessage());
+        }
     }
     
     public void settings() {

--- a/src/StrokeManager.java
+++ b/src/StrokeManager.java
@@ -475,7 +475,7 @@ public class StrokeManager {
         }
         
         // Create project directory structure
-        File projectDir = new File("project/" + projectId);
+        File projectDir = QuantumBrush.appFile("project/" + projectId);
         if (!projectDir.exists()) {
             projectDir.mkdirs();
             
@@ -493,9 +493,10 @@ public class StrokeManager {
         }
         
         // Generate and save JSON instructions
-        String instructionsPath = strokeDir.getPath() + "/" + strokeId + "_instructions.json";
+        String instructionsPath = "project/" + projectId + "/stroke/" + strokeId + "_instructions.json";
+        File instructionsFile = QuantumBrush.appFile(instructionsPath);
         JSONObject instructions = stroke.generateJSON(projectId, app.getHardwareManager().snapshotForStroke());
-        app.saveJSONObject(instructions, instructionsPath);
+        app.saveJSONObject(instructions, instructionsFile.getAbsolutePath());
 
         // DEBUG: Show the final JSON that was saved
         DebugLogger.log("\n=== FINAL SAVED JSON DEBUG ===");
@@ -518,11 +519,11 @@ public class StrokeManager {
         if (app.getCurrentImage() != null) {
             strokeInputImages.put(strokeId, app.getCurrentImage().copy());
 
-            instructions = app.loadJSONObject(instructionsPath);
+            instructions = app.loadJSONObject(instructionsFile.getAbsolutePath());
             JSONObject strokeInput = instructions.getJSONObject("stroke_input");
             strokeInput.setString("transport", "stdio_png");
             instructions.setJSONObject("stroke_input", strokeInput);
-            app.saveJSONObject(instructions, instructionsPath);
+            app.saveJSONObject(instructions, instructionsFile.getAbsolutePath());
         }
         
         // Set current stroke index
@@ -538,7 +539,7 @@ public class StrokeManager {
         }
         
         String projectId = app.getProjectId();
-        File strokeDir = new File("project/" + projectId + "/stroke");
+        File strokeDir = QuantumBrush.appFile("project/" + projectId + "/stroke");
         
         if (!strokeDir.exists() || !strokeDir.isDirectory()) {
             return;
@@ -628,19 +629,7 @@ public class StrokeManager {
                 // ✅ FIXED: Extract path data correctly - preserve separate paths
                 // ✅ CRITICAL FIX: Reconstruct SEPARATE paths correctly
                 JSONObject strokeInput = instructions.getJSONObject("stroke_input");
-                String transport = strokeInput.getString("transport", "");
-                boolean usesInMemoryTransport = "stdio_png".equals(transport);
-                boolean completedWithoutAvailableResult =
-                    usesInMemoryTransport &&
-                    "completed".equals(instructions.getString("processing_status", "")) &&
-                    !strokeResultImages.containsKey(strokeId) &&
-                    !new File("project/" + projectId + "/stroke/" + strokeId + "_output.png").exists();
-
-                if (completedWithoutAvailableResult) {
-                    instructions.setString("processing_status", "pending");
-                    instructions.setString("effect_success", "null");
-                    app.saveJSONObject(instructions, file.getAbsolutePath());
-                }
+                restorePersistentStrokeImages(strokeId, instructions);
 
                 JSONArray pathArray = strokeInput.getJSONArray("path");
                 JSONArray clicksArray = strokeInput.getJSONArray("clicks");
@@ -862,11 +851,11 @@ public void runStroke(Stroke stroke) {
         
         // Define instructionsPath once here to use throughout the method
         final String instructionsPath = "project/" + projectId + "/stroke/" + strokeId + "_instructions.json";
-        File instructionsFile = new File(instructionsPath);
+        File instructionsFile = QuantumBrush.appFile(instructionsPath);
         
         // Check if the stroke is in a failed state and needs cleanup
         if (instructionsFile.exists()) {
-            JSONObject instructions = app.loadJSONObject(instructionsPath);
+            JSONObject instructions = app.loadJSONObject(instructionsFile.getAbsolutePath());
             String processingStatus = instructions.getString("processing_status", "");
             
             // If the stroke is in a "running" state but not in our processing map,
@@ -874,15 +863,15 @@ public void runStroke(Stroke stroke) {
             if ("running".equals(processingStatus) && !processingStrokes.containsKey(strokeId)) {
                 // Reset the status to allow reprocessing
                 instructions.setString("processing_status", "pending");
-                app.saveJSONObject(instructions, instructionsPath);
+                app.saveJSONObject(instructions, instructionsFile.getAbsolutePath());
             }
         }
         
         // Check if Python script exists
-        File pythonScript = new File("effect/" + folderName + "/" + effectId + ".py");
+        File pythonScript = QuantumBrush.appFile("effect/" + folderName + "/" + effectId + ".py");
         if (!pythonScript.exists()) {
             // Try with folder name as fallback
-            pythonScript = new File("effect/" + folderName + "/" + folderName + ".py");
+            pythonScript = QuantumBrush.appFile("effect/" + folderName + "/" + folderName + ".py");
             if (!pythonScript.exists()) {
                 JOptionPane.showMessageDialog(
                     null, 
@@ -895,7 +884,7 @@ public void runStroke(Stroke stroke) {
         }
         
         // Ensure directories exist
-        File projectDir = new File("project/" + projectId);
+        File projectDir = QuantumBrush.appFile("project/" + projectId);
         File strokeDir = new File(projectDir, "stroke");
         if (!projectDir.exists()) projectDir.mkdirs();
         if (!strokeDir.exists()) strokeDir.mkdirs();
@@ -903,17 +892,17 @@ public void runStroke(Stroke stroke) {
         // Ensure instructions file exists
         if (!instructionsFile.exists()) {
             JSONObject instructions = stroke.generateJSON(projectId, app.getHardwareManager().snapshotForStroke());
-            app.saveJSONObject(instructions, instructionsPath);
+            app.saveJSONObject(instructions, instructionsFile.getAbsolutePath());
         }
         
         // Update status fields to indicate processing has started
-        JSONObject instructions = app.loadJSONObject(instructionsPath);
+        JSONObject instructions = app.loadJSONObject(instructionsFile.getAbsolutePath());
         instructions.setBoolean("created", true);
         instructions.setString("effect_received", "null");
         instructions.setString("effect_processed", "null");
         instructions.setString("effect_success", "null");
         instructions.setString("processing_status", "running");
-        app.saveJSONObject(instructions, instructionsPath);
+        app.saveJSONObject(instructions, instructionsFile.getAbsolutePath());
         
         // Create a task to execute the Python script asynchronously
         Runnable task = () -> {
@@ -924,13 +913,13 @@ public void runStroke(Stroke stroke) {
                 success = executeApplyEffectScriptInMemory(instructionsFile.getAbsolutePath());
                 
                 // Update status based on result
-                JSONObject updatedInstructions = app.loadJSONObject(instructionsPath);
+                JSONObject updatedInstructions = app.loadJSONObject(instructionsFile.getAbsolutePath());
                 if (success) {
                     updatedInstructions.setString("effect_received", "true");
                     updatedInstructions.setString("effect_processed", "true");
                     updatedInstructions.setString("effect_success", "true");
                     updatedInstructions.setString("processing_status", "completed");
-                    app.saveJSONObject(updatedInstructions, instructionsPath);
+                    app.saveJSONObject(updatedInstructions, instructionsFile.getAbsolutePath());
                     
                     // Notify on the Event Dispatch Thread
                     SwingUtilities.invokeLater(() -> {
@@ -941,7 +930,7 @@ public void runStroke(Stroke stroke) {
                     updatedInstructions.setString("effect_processed", "true");
                     updatedInstructions.setString("effect_success", "false");
                     updatedInstructions.setString("processing_status", "failed");
-                    app.saveJSONObject(updatedInstructions, instructionsPath);
+                    app.saveJSONObject(updatedInstructions, instructionsFile.getAbsolutePath());
                     
                     // Notify on the Event Dispatch Thread
                     SwingUtilities.invokeLater(() -> {
@@ -954,11 +943,11 @@ public void runStroke(Stroke stroke) {
                 
                 // Update the instructions file to reflect cancellation
                 try {
-                    JSONObject updatedInstructions = app.loadJSONObject(instructionsPath);
+                    JSONObject updatedInstructions = app.loadJSONObject(instructionsFile.getAbsolutePath());
                     updatedInstructions.setString("effect_success", "false");
                     updatedInstructions.setString("processing_status", "canceled");
                     updatedInstructions.setString("error_message", "Process was cancelled by user");
-                    app.saveJSONObject(updatedInstructions, instructionsPath);
+                    app.saveJSONObject(updatedInstructions, instructionsFile.getAbsolutePath());
                 } catch (Exception ex) {
                     System.err.println("Error updating instructions file after cancellation: " + ex.getMessage());
                 }
@@ -975,11 +964,11 @@ public void runStroke(Stroke stroke) {
                 e.printStackTrace();
                 
                 try {
-                    JSONObject updatedInstructions = app.loadJSONObject(instructionsPath);
+                    JSONObject updatedInstructions = app.loadJSONObject(instructionsFile.getAbsolutePath());
                     updatedInstructions.setString("effect_success", "false");
                     updatedInstructions.setString("processing_status", "failed");
                     updatedInstructions.setString("error_message", e.getMessage());
-                    app.saveJSONObject(updatedInstructions, instructionsPath);
+                    app.saveJSONObject(updatedInstructions, instructionsFile.getAbsolutePath());
                 } catch (Exception ex) {
                     System.err.println("Error updating instructions file: " + ex.getMessage());
                 }
@@ -1200,14 +1189,14 @@ public void runStroke(Stroke stroke) {
             }
             
             // Create log directory if it doesn't exist
-            File logDir = new File("log");
+            File logDir = QuantumBrush.appFile("log");
             if (!logDir.exists()) {
                 logDir.mkdirs();
             }
             
             // Create log files for stdout and stderr
-            File stdoutLog = new File("log/python_stdout.log");
-            File stderrLog = new File("log/python_stderr.log");
+            File stdoutLog = QuantumBrush.appFile("log/python_stdout.log");
+            File stderrLog = QuantumBrush.appFile("log/python_stderr.log");
             
             // Display Python version information
             ProcessBuilder versionProcessBuilder = new ProcessBuilder(pythonCommand, "--version");
@@ -1248,14 +1237,18 @@ public void runStroke(Stroke stroke) {
             
             // Create command to execute Python script
             ProcessBuilder processBuilder = new ProcessBuilder(
-                pythonCommand, "effect/apply_effect.py", instructionsFilePath
+                pythonCommand,
+                QuantumBrush.appFile("effect/apply_effect.py").getAbsolutePath(),
+                QuantumBrush.appFile(instructionsFilePath).getAbsolutePath()
             );
+            processBuilder.directory(QuantumBrush.getAppRootDirectory());
             processBuilder.redirectOutput(ProcessBuilder.Redirect.appendTo(stdoutLog));
             processBuilder.redirectError(ProcessBuilder.Redirect.appendTo(stderrLog));
 
             // Pass the IQM token through the subprocess environment when the
             // user has chosen the IQM backend. The token never lands on disk.
             app.getHardwareManager().applyToProcessEnv(processBuilder.environment());
+            addLocalPythonPackages(processBuilder.environment());
 
             // Execute process
             process = processBuilder.start();
@@ -1273,7 +1266,7 @@ public void runStroke(Stroke stroke) {
             String projectId = instructions.getString("project_id", "");
             String strokeId = instructions.getString("stroke_id", "");
             String outputPath = "project/" + projectId + "/stroke/" + strokeId + "_output.png";
-            File outputFile = new File(outputPath);
+            File outputFile = QuantumBrush.appFile(outputPath);
             String effectSuccess = instructions.getString("effect_success", "false");
             
             boolean success = exitCode == 0 && "true".equals(effectSuccess) && outputFile.exists();
@@ -1325,15 +1318,33 @@ public void runStroke(Stroke stroke) {
     
     private boolean executeApplyEffectScriptInMemory(String instructionsFilePath)
             throws InterruptedException, IOException {
+        JSONObject instructions = app.loadJSONObject(instructionsFilePath);
+        String strokeId = instructions.getString("stroke_id", "");
+        PImage inputImage = strokeInputImages.get(strokeId);
+        if (inputImage == null) {
+            inputImage = app.getCurrentImage();
+        }
+        if (inputImage == null) {
+            throw new IOException("No input image is available for stroke " + strokeId);
+        }
+
+        return executeApplyEffectScriptInMemory(instructionsFilePath, inputImage, true);
+    }
+
+    private boolean executeApplyEffectScriptInMemory(
+        String instructionsFilePath,
+        PImage inputImage,
+        boolean persistResult
+    ) throws InterruptedException, IOException {
         Process process = null;
-        File stderrLog = new File("log/python_stderr.log");
+        File stderrLog = QuantumBrush.appFile("log/python_stderr.log");
 
         try {
             if (pythonCommand == null) {
                 initializePythonCommand();
             }
 
-            File logDir = new File("log");
+            File logDir = QuantumBrush.appFile("log");
             if (!logDir.exists()) {
                 logDir.mkdirs();
             }
@@ -1373,20 +1384,20 @@ public void runStroke(Stroke stroke) {
 
             JSONObject instructions = app.loadJSONObject(instructionsFilePath);
             String strokeId = instructions.getString("stroke_id", "");
-            PImage inputImage = strokeInputImages.get(strokeId);
-            if (inputImage == null) {
-                inputImage = app.getCurrentImage();
-            }
             if (inputImage == null) {
                 throw new IOException("No input image is available for stroke " + strokeId);
             }
 
             ProcessBuilder processBuilder = new ProcessBuilder(
-                pythonCommand, "effect/apply_effect.py", "--stdio"
+                pythonCommand,
+                QuantumBrush.appFile("effect/apply_effect.py").getAbsolutePath(),
+                "--stdio"
             );
+            processBuilder.directory(QuantumBrush.getAppRootDirectory());
             processBuilder.redirectError(ProcessBuilder.Redirect.appendTo(stderrLog));
 
             app.getHardwareManager().applyToProcessEnv(processBuilder.environment());
+            addLocalPythonPackages(processBuilder.environment());
 
             process = processBuilder.start();
 
@@ -1401,7 +1412,11 @@ public void runStroke(Stroke stroke) {
             boolean success = exitCode == 0 && "true".equals(effectSuccess);
 
             if (success) {
-                strokeResultImages.put(strokeId, pngBytesToPImage(binaryResponse.imageBytes));
+                PImage resultImage = pngBytesToPImage(binaryResponse.imageBytes);
+                strokeResultImages.put(strokeId, resultImage);
+                if (persistResult) {
+                    persistStrokeImages(instructionsFilePath, inputImage, resultImage);
+                }
             } else {
                 System.err.println("Python script execution failed with exit code: " + exitCode);
                 System.err.println("Effect success flag: " + effectSuccess);
@@ -1428,6 +1443,21 @@ public void runStroke(Stroke stroke) {
             }
 
             throw e;
+        }
+    }
+
+    private void addLocalPythonPackages(Map<String, String> environment) {
+        File localPackages = QuantumBrush.appFile(".python-packages");
+        if (!localPackages.isDirectory()) {
+            return;
+        }
+
+        String packagePath = localPackages.getAbsolutePath();
+        String currentPath = environment.get("PYTHONPATH");
+        if (currentPath == null || currentPath.isEmpty()) {
+            environment.put("PYTHONPATH", packagePath);
+        } else if (!Arrays.asList(currentPath.split(File.pathSeparator)).contains(packagePath)) {
+            environment.put("PYTHONPATH", packagePath + File.pathSeparator + currentPath);
         }
     }
 
@@ -1534,6 +1564,282 @@ public void runStroke(Stroke stroke) {
         return image;
     }
 
+    private void persistStrokeImages(String instructionsFilePath, PImage inputImage, PImage resultImage) {
+        try {
+            JSONObject instructions = app.loadJSONObject(instructionsFilePath);
+            JSONObject serialized = new JSONObject();
+
+            PImage inputPreview = createPreviewImage(inputImage, 360);
+            serialized.setString("input_preview_png", pImageToBase64Png(inputPreview));
+            serialized.setInt("input_preview_width", inputPreview.width);
+            serialized.setInt("input_preview_height", inputPreview.height);
+
+            JSONObject resultPatch = createResultPatch(resultImage);
+            serialized.setJSONObject("result_patch", resultPatch);
+            instructions.setJSONObject("serialized_images", serialized);
+
+            app.saveJSONObject(instructions, instructionsFilePath);
+        } catch (Exception e) {
+            System.err.println("Could not persist in-memory stroke result: " + e.getMessage());
+        }
+    }
+
+    private void restorePersistentStrokeImages(String strokeId, JSONObject instructions) {
+        if (!instructions.hasKey("serialized_images")) {
+            return;
+        }
+
+        try {
+            JSONObject serialized = instructions.getJSONObject("serialized_images");
+            String inputPreview = serialized.getString("input_preview_png", "");
+            if (!inputPreview.isEmpty()) {
+                strokeInputImages.put(strokeId, base64PngToPImage(inputPreview));
+            }
+
+            if (serialized.hasKey("result_patch")) {
+                PImage resultImage = restoreResultPatch(serialized.getJSONObject("result_patch"));
+                if (resultImage != null) {
+                    strokeResultImages.put(strokeId, resultImage);
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("Could not restore serialized stroke images: " + e.getMessage());
+        }
+    }
+
+    private JSONObject createResultPatch(PImage image) throws IOException {
+        image.loadPixels();
+
+        int minX = image.width;
+        int minY = image.height;
+        int maxX = -1;
+        int maxY = -1;
+
+        for (int y = 0; y < image.height; y++) {
+            for (int x = 0; x < image.width; x++) {
+                int pixel = image.pixels[y * image.width + x];
+                int alpha = (pixel >>> 24) & 0xFF;
+                if (alpha != 0) {
+                    minX = Math.min(minX, x);
+                    minY = Math.min(minY, y);
+                    maxX = Math.max(maxX, x);
+                    maxY = Math.max(maxY, y);
+                }
+            }
+        }
+
+        JSONObject patch = new JSONObject();
+        patch.setInt("canvas_width", image.width);
+        patch.setInt("canvas_height", image.height);
+
+        if (maxX < minX || maxY < minY) {
+            patch.setBoolean("empty", true);
+            patch.setInt("x", 0);
+            patch.setInt("y", 0);
+            patch.setInt("width", 0);
+            patch.setInt("height", 0);
+            patch.setString("png", "");
+            return patch;
+        }
+
+        int patchWidth = maxX - minX + 1;
+        int patchHeight = maxY - minY + 1;
+        PImage crop = app.createImage(patchWidth, patchHeight, PConstants.ARGB);
+        crop.loadPixels();
+        for (int y = 0; y < patchHeight; y++) {
+            for (int x = 0; x < patchWidth; x++) {
+                crop.pixels[y * patchWidth + x] = image.pixels[(minY + y) * image.width + minX + x];
+            }
+        }
+        crop.updatePixels();
+
+        patch.setBoolean("empty", false);
+        patch.setInt("x", minX);
+        patch.setInt("y", minY);
+        patch.setInt("width", patchWidth);
+        patch.setInt("height", patchHeight);
+        patch.setString("png", pImageToBase64Png(crop));
+        return patch;
+    }
+
+    private PImage restoreResultPatch(JSONObject patch) throws IOException {
+        int canvasWidth = patch.getInt("canvas_width", 0);
+        int canvasHeight = patch.getInt("canvas_height", 0);
+        if (canvasWidth <= 0 || canvasHeight <= 0) {
+            return null;
+        }
+
+        PImage image = app.createImage(canvasWidth, canvasHeight, PConstants.ARGB);
+        image.loadPixels();
+        Arrays.fill(image.pixels, 0);
+
+        if (!patch.getBoolean("empty", false)) {
+            PImage crop = base64PngToPImage(patch.getString("png", ""));
+            int offsetX = patch.getInt("x", 0);
+            int offsetY = patch.getInt("y", 0);
+            crop.loadPixels();
+            for (int y = 0; y < crop.height; y++) {
+                for (int x = 0; x < crop.width; x++) {
+                    int targetX = offsetX + x;
+                    int targetY = offsetY + y;
+                    if (targetX >= 0 && targetX < canvasWidth && targetY >= 0 && targetY < canvasHeight) {
+                        image.pixels[targetY * canvasWidth + targetX] = crop.pixels[y * crop.width + x];
+                    }
+                }
+            }
+        }
+
+        image.updatePixels();
+        return image;
+    }
+
+    private PImage createPreviewImage(PImage image, int maxSize) {
+        int width = image.width;
+        int height = image.height;
+        float scale = Math.min(1.0f, maxSize / (float)Math.max(width, height));
+        int previewWidth = Math.max(1, Math.round(width * scale));
+        int previewHeight = Math.max(1, Math.round(height * scale));
+
+        if (previewWidth == width && previewHeight == height) {
+            return image.copy();
+        }
+
+        PImage preview = image.copy();
+        preview.resize(previewWidth, previewHeight);
+        return preview;
+    }
+
+    private String pImageToBase64Png(PImage image) throws IOException {
+        return Base64.getEncoder().encodeToString(pImageToPngBytes(image));
+    }
+
+    private PImage base64PngToPImage(String encoded) throws IOException {
+        if (encoded == null || encoded.isEmpty()) {
+            throw new IOException("Missing encoded PNG data.");
+        }
+        return pngBytesToPImage(Base64.getDecoder().decode(encoded));
+    }
+
+    private PImage processStrokeImageInMemory(String instructionsFilePath, PImage inputImage)
+            throws InterruptedException, IOException {
+        boolean success = executeApplyEffectScriptInMemory(instructionsFilePath, inputImage, true);
+        if (!success) {
+            return null;
+        }
+
+        JSONObject instructions = app.loadJSONObject(instructionsFilePath);
+        return strokeResultImages.get(instructions.getString("stroke_id", ""));
+    }
+
+    private PImage resolveInputImageForStroke(String strokeId)
+            throws InterruptedException, IOException {
+        PImage inputImage = strokeInputImages.get(strokeId);
+        if (inputImage != null) {
+            return inputImage.copy();
+        }
+
+        inputImage = reconstructImageBeforeStroke(strokeId);
+        if (inputImage != null) {
+            strokeInputImages.put(strokeId, inputImage.copy());
+            return inputImage;
+        }
+
+        PImage currentImage = app.getCurrentImage();
+        return currentImage != null ? currentImage.copy() : null;
+    }
+
+    private PImage reconstructImageBeforeStroke(String targetStrokeId)
+            throws InterruptedException, IOException {
+        String projectId = app.getProjectId();
+        if (projectId == null || targetStrokeId == null || targetStrokeId.isEmpty()) {
+            return null;
+        }
+
+        PImage baseImage = app.loadImage(
+            QuantumBrush.appFile("project/" + projectId + "/original.png").getAbsolutePath()
+        );
+        if (baseImage == null) {
+            return null;
+        }
+
+        ArrayList<Stroke> orderedStrokes = new ArrayList<>(strokes);
+        orderedStrokes.sort((a, b) -> Long.compare(strokeTimestamp(a.getId()), strokeTimestamp(b.getId())));
+
+        PImage imageBeforeTarget = baseImage.copy();
+        for (Stroke stroke : orderedStrokes) {
+            String strokeId = stroke.getId();
+            if (strokeId.equals(targetStrokeId)) {
+                return imageBeforeTarget;
+            }
+
+            String instructionsPath = "project/" + projectId + "/stroke/" + strokeId + "_instructions.json";
+            File instructionsFile = QuantumBrush.appFile(instructionsPath);
+            if (!instructionsFile.exists()) {
+                continue;
+            }
+
+            JSONObject instructions = app.loadJSONObject(instructionsFile.getAbsolutePath());
+            boolean appliedOrCompleted =
+                "true".equals(instructions.getString("effect_success", "false")) ||
+                "completed".equals(instructions.getString("processing_status", ""));
+            if (!appliedOrCompleted) {
+                continue;
+            }
+
+            PImage effectImage = strokeResultImages.get(strokeId);
+            if (effectImage == null) {
+                restorePersistentStrokeImages(strokeId, instructions);
+                effectImage = strokeResultImages.get(strokeId);
+            }
+            if (effectImage == null) {
+                String outputPath = "project/" + projectId + "/stroke/" + strokeId + "_output.png";
+                effectImage = app.loadImage(QuantumBrush.appFile(outputPath).getAbsolutePath());
+            }
+            if (effectImage == null) {
+                strokeInputImages.put(strokeId, imageBeforeTarget.copy());
+                effectImage = processStrokeImageInMemory(instructionsFile.getAbsolutePath(), imageBeforeTarget.copy());
+            }
+            if (effectImage != null) {
+                imageBeforeTarget = blendEffectOntoImage(imageBeforeTarget, effectImage);
+            }
+        }
+
+        return null;
+    }
+
+    private PImage blendEffectOntoImage(PImage baseImage, PImage effectImage) {
+        PImage resultImage = app.createImage(baseImage.width, baseImage.height, PConstants.ARGB);
+        resultImage.copy(
+            baseImage,
+            0, 0, baseImage.width, baseImage.height,
+            0, 0, resultImage.width, resultImage.height
+        );
+        resultImage.blend(
+            effectImage,
+            0, 0, effectImage.width, effectImage.height,
+            0, 0, resultImage.width, resultImage.height,
+            PConstants.BLEND
+        );
+        return resultImage;
+    }
+
+    private long strokeTimestamp(String strokeId) {
+        if (strokeId == null) {
+            return 0L;
+        }
+
+        int underscore = strokeId.indexOf('_');
+        if (underscore < 0 || underscore + 1 >= strokeId.length()) {
+            return 0L;
+        }
+
+        try {
+            return Long.parseLong(strokeId.substring(underscore + 1));
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
+    }
+
     /**
      * FIXED: Apply effect to canvas by properly layering on top of current image
      * This method now correctly preserves previous effects and creates proper undo states
@@ -1548,7 +1854,7 @@ public void runStroke(Stroke stroke) {
         // Check if the effect was successful
         String instructionsPath = "project/" + projectId + "/stroke/" + 
                                  strokeId + "_instructions.json";
-        File instructionsFile = new File(instructionsPath);
+        File instructionsFile = QuantumBrush.appFile(instructionsPath);
         
         if (!instructionsFile.exists()) {
             JOptionPane.showMessageDialog(
@@ -1560,7 +1866,7 @@ public void runStroke(Stroke stroke) {
             return false;
         }
         
-        JSONObject instructions = app.loadJSONObject(instructionsPath);
+        JSONObject instructions = app.loadJSONObject(instructionsFile.getAbsolutePath());
         String effectSuccess = instructions.getString("effect_success", "false");
         
         if (!"true".equals(effectSuccess)) {
@@ -1578,8 +1884,24 @@ public void runStroke(Stroke stroke) {
         // a per-stroke output PNG. Legacy projects can still load output files.
         PImage effectImage = strokeResultImages.get(strokeId);
         if (effectImage == null) {
+            restorePersistentStrokeImages(strokeId, instructions);
+            effectImage = strokeResultImages.get(strokeId);
+        }
+        if (effectImage == null) {
             String outputPath = "project/" + projectId + "/stroke/" + strokeId + "_output.png";
-            effectImage = app.loadImage(outputPath);
+            effectImage = app.loadImage(QuantumBrush.appFile(outputPath).getAbsolutePath());
+        }
+        if (effectImage == null) {
+            try {
+                PImage inputImage = resolveInputImageForStroke(strokeId);
+                if (inputImage != null) {
+                    effectImage = processStrokeImageInMemory(instructionsFile.getAbsolutePath(), inputImage);
+                }
+            } catch (Exception e) {
+                System.err.println(
+                    "Could not regenerate effect output for stroke " + strokeId + ": " + e.getMessage()
+                );
+            }
         }
         
         if (effectImage == null) {
@@ -1724,6 +2046,16 @@ public void runStroke(Stroke stroke) {
 
     public boolean hasInMemoryResult(String strokeId) {
         return strokeResultImages.containsKey(strokeId);
+    }
+
+    public PImage getInMemoryInput(String strokeId) {
+        PImage image = strokeInputImages.get(strokeId);
+        return image != null ? image.copy() : null;
+    }
+
+    public PImage getInMemoryResult(String strokeId) {
+        PImage image = strokeResultImages.get(strokeId);
+        return image != null ? image.copy() : null;
     }
     
     public void clearStrokes() {

--- a/src/StrokeManager.java
+++ b/src/StrokeManager.java
@@ -4,8 +4,11 @@ import java.util.*;
 import java.io.*;
 import javax.swing.*;
 import java.awt.*;
+import java.awt.image.BufferedImage;
 import java.nio.file.Files;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.*;
+import javax.imageio.ImageIO;
 
 public class StrokeManager {
   private QuantumBrush app;
@@ -19,6 +22,8 @@ public class StrokeManager {
   
   // Map to track which strokes are currently being processed
   private Map<String, Future<?>> processingStrokes;
+  private Map<String, PImage> strokeInputImages;
+  private Map<String, PImage> strokeResultImages;
   
   // Callback interface for UI updates
   public interface ProcessingCallback {
@@ -32,6 +37,8 @@ public class StrokeManager {
       this.strokes = new ArrayList<>();
       this.executorService = Executors.newFixedThreadPool(3); // Allow up to 3 concurrent processes
       this.processingStrokes = new ConcurrentHashMap<>();
+      this.strokeInputImages = new ConcurrentHashMap<>();
+      this.strokeResultImages = new ConcurrentHashMap<>();
       this.callbacks = new ArrayList<>();
       
       // Initialize Python command on startup
@@ -506,19 +513,14 @@ public class StrokeManager {
         }
         DebugLogger.log("=== END FINAL SAVED JSON DEBUG ===\n");
         
-        // Save input image
+        // Keep the input image in memory. The persistent stroke JSON remains
+        // lightweight and no per-stroke input PNG is written to disk.
         if (app.getCurrentImage() != null) {
-            String inputPath = strokeDir.getPath() + "/" + strokeId + "_input.png";
-            app.getCurrentImage().save(inputPath);
-            
-            // Update JSON with image paths
+            strokeInputImages.put(strokeId, app.getCurrentImage().copy());
+
             instructions = app.loadJSONObject(instructionsPath);
             JSONObject strokeInput = instructions.getJSONObject("stroke_input");
-            strokeInput.setString("input_location", inputPath);
-            strokeInput.setString(
-            "output_location", 
-            strokeDir.getPath() + "/" + strokeId + "_output.png"
-            );
+            strokeInput.setString("transport", "stdio_png");
             instructions.setJSONObject("stroke_input", strokeInput);
             app.saveJSONObject(instructions, instructionsPath);
         }
@@ -626,6 +628,20 @@ public class StrokeManager {
                 // ✅ FIXED: Extract path data correctly - preserve separate paths
                 // ✅ CRITICAL FIX: Reconstruct SEPARATE paths correctly
                 JSONObject strokeInput = instructions.getJSONObject("stroke_input");
+                String transport = strokeInput.getString("transport", "");
+                boolean usesInMemoryTransport = "stdio_png".equals(transport);
+                boolean completedWithoutAvailableResult =
+                    usesInMemoryTransport &&
+                    "completed".equals(instructions.getString("processing_status", "")) &&
+                    !strokeResultImages.containsKey(strokeId) &&
+                    !new File("project/" + projectId + "/stroke/" + strokeId + "_output.png").exists();
+
+                if (completedWithoutAvailableResult) {
+                    instructions.setString("processing_status", "pending");
+                    instructions.setString("effect_success", "null");
+                    app.saveJSONObject(instructions, file.getAbsolutePath());
+                }
+
                 JSONArray pathArray = strokeInput.getJSONArray("path");
                 JSONArray clicksArray = strokeInput.getJSONArray("clicks");
 
@@ -905,7 +921,7 @@ public void runStroke(Stroke stroke) {
             
             try {
                 // Execute Python script with absolute path
-                success = executeApplyEffectScript(instructionsFile.getAbsolutePath());
+                success = executeApplyEffectScriptInMemory(instructionsFile.getAbsolutePath());
                 
                 // Update status based on result
                 JSONObject updatedInstructions = app.loadJSONObject(instructionsPath);
@@ -1307,6 +1323,217 @@ public void runStroke(Stroke stroke) {
         }
     }
     
+    private boolean executeApplyEffectScriptInMemory(String instructionsFilePath)
+            throws InterruptedException, IOException {
+        Process process = null;
+        File stderrLog = new File("log/python_stderr.log");
+
+        try {
+            if (pythonCommand == null) {
+                initializePythonCommand();
+            }
+
+            File logDir = new File("log");
+            if (!logDir.exists()) {
+                logDir.mkdirs();
+            }
+
+            ProcessBuilder versionProcessBuilder = new ProcessBuilder(pythonCommand, "--version");
+            versionProcessBuilder.redirectErrorStream(true);
+
+            Process versionProcess = versionProcessBuilder.start();
+            BufferedReader versionReader = new BufferedReader(
+                new InputStreamReader(versionProcess.getInputStream())
+            );
+            String versionLine;
+            while ((versionLine = versionReader.readLine()) != null) {
+                System.out.println(
+                    "Using Python: " + versionLine + " (from: " + pythonCommand + ")"
+                );
+
+                if (versionLine.matches(".*Python 3\\.[0-9](\\..*)?")) {
+                    String minorVersionStr = versionLine.replaceAll(
+                        ".*Python 3\\.([0-9])(\\..*)?", "$1"
+                    );
+                    try {
+                        int minorVersion = Integer.parseInt(minorVersionStr);
+                        if (minorVersion < 10) {
+                            System.err.println(
+                                "WARNING: Python version is " + versionLine +
+                                " but match-case syntax requires Python 3.10 or higher!"
+                            );
+                            return false;
+                        }
+                    } catch (NumberFormatException e) {
+                        System.err.println("Could not parse Python version: " + versionLine);
+                    }
+                }
+            }
+            versionProcess.waitFor();
+
+            JSONObject instructions = app.loadJSONObject(instructionsFilePath);
+            String strokeId = instructions.getString("stroke_id", "");
+            PImage inputImage = strokeInputImages.get(strokeId);
+            if (inputImage == null) {
+                inputImage = app.getCurrentImage();
+            }
+            if (inputImage == null) {
+                throw new IOException("No input image is available for stroke " + strokeId);
+            }
+
+            ProcessBuilder processBuilder = new ProcessBuilder(
+                pythonCommand, "effect/apply_effect.py", "--stdio"
+            );
+            processBuilder.redirectError(ProcessBuilder.Redirect.appendTo(stderrLog));
+
+            app.getHardwareManager().applyToProcessEnv(processBuilder.environment());
+
+            process = processBuilder.start();
+
+            System.out.println("Starting in-memory effect processing...");
+            writeBinaryRequest(process.getOutputStream(), instructions, pImageToPngBytes(inputImage));
+            BinaryResponse binaryResponse = readBinaryResponse(process.getInputStream());
+            process.waitFor();
+
+            int exitCode = process.exitValue();
+            JSONObject response = JSONObject.parse(binaryResponse.json);
+            String effectSuccess = response.getString("effect_success", "false");
+            boolean success = exitCode == 0 && "true".equals(effectSuccess);
+
+            if (success) {
+                strokeResultImages.put(strokeId, pngBytesToPImage(binaryResponse.imageBytes));
+            } else {
+                System.err.println("Python script execution failed with exit code: " + exitCode);
+                System.err.println("Effect success flag: " + effectSuccess);
+                logPythonErrors(stderrLog);
+            }
+
+            return success;
+        } catch (InterruptedException e) {
+            System.err.println("Process execution interrupted");
+
+            if (process != null && process.isAlive()) {
+                process.destroyForcibly();
+                System.out.println("Forcibly terminated process due to cancellation");
+            }
+
+            try {
+                JSONObject instructions = app.loadJSONObject(instructionsFilePath);
+                instructions.setString("effect_success", "false");
+                instructions.setString("processing_status", "canceled");
+                instructions.setString("error_message", "Process was cancelled by user");
+                app.saveJSONObject(instructions, instructionsFilePath);
+            } catch (Exception ex) {
+                System.err.println("Error updating instructions file after cancellation: " + ex.getMessage());
+            }
+
+            throw e;
+        }
+    }
+
+    private void logPythonErrors(File stderrLog) {
+        if (!stderrLog.exists()) {
+            return;
+        }
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(stderrLog))) {
+            String line;
+            System.err.println("Python error log:");
+            while ((line = reader.readLine()) != null) {
+                System.err.println("  " + line);
+            }
+        } catch (IOException e) {
+            System.err.println("Could not read error log: " + e.getMessage());
+        }
+    }
+
+    private static class BinaryResponse {
+        String json;
+        byte[] imageBytes;
+
+        BinaryResponse(String json, byte[] imageBytes) {
+            this.json = json;
+            this.imageBytes = imageBytes;
+        }
+    }
+
+    private void writeBinaryRequest(
+        OutputStream outputStream,
+        JSONObject instructions,
+        byte[] imageBytes
+    ) throws IOException {
+        byte[] jsonBytes = instructions.toString().getBytes(StandardCharsets.UTF_8);
+        DataOutputStream output = new DataOutputStream(new BufferedOutputStream(outputStream));
+        output.writeInt(jsonBytes.length);
+        output.write(jsonBytes);
+        output.writeInt(imageBytes.length);
+        output.write(imageBytes);
+        output.flush();
+        output.close();
+    }
+
+    private BinaryResponse readBinaryResponse(InputStream inputStream) throws IOException {
+        DataInputStream input = new DataInputStream(new BufferedInputStream(inputStream));
+        int jsonLength = input.readInt();
+        if (jsonLength < 0) {
+            throw new IOException("Python returned an invalid response header.");
+        }
+
+        byte[] jsonBytes = new byte[jsonLength];
+        input.readFully(jsonBytes);
+
+        int imageLength = input.readInt();
+        if (imageLength < 0) {
+            throw new IOException("Python returned an invalid image payload header.");
+        }
+
+        byte[] imageBytes = new byte[imageLength];
+        if (imageLength > 0) {
+            input.readFully(imageBytes);
+        }
+
+        return new BinaryResponse(new String(jsonBytes, StandardCharsets.UTF_8), imageBytes);
+    }
+
+    private byte[] pImageToPngBytes(PImage image) throws IOException {
+        BufferedImage bufferedImage = new BufferedImage(
+            image.width,
+            image.height,
+            BufferedImage.TYPE_INT_ARGB
+        );
+        image.loadPixels();
+        for (int y = 0; y < image.height; y++) {
+            for (int x = 0; x < image.width; x++) {
+                bufferedImage.setRGB(x, y, image.pixels[y * image.width + x]);
+            }
+        }
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ImageIO.write(bufferedImage, "png", output);
+        return output.toByteArray();
+    }
+
+    private PImage pngBytesToPImage(byte[] imageBytes) throws IOException {
+        BufferedImage bufferedImage = ImageIO.read(new ByteArrayInputStream(imageBytes));
+        if (bufferedImage == null) {
+            throw new IOException("Python returned an invalid PNG payload.");
+        }
+
+        PImage image = app.createImage(
+            bufferedImage.getWidth(),
+            bufferedImage.getHeight(),
+            PConstants.ARGB
+        );
+        image.loadPixels();
+        for (int y = 0; y < bufferedImage.getHeight(); y++) {
+            for (int x = 0; x < bufferedImage.getWidth(); x++) {
+                image.pixels[y * bufferedImage.getWidth() + x] = bufferedImage.getRGB(x, y);
+            }
+        }
+        image.updatePixels();
+        return image;
+    }
+
     /**
      * FIXED: Apply effect to canvas by properly layering on top of current image
      * This method now correctly preserves previous effects and creates proper undo states
@@ -1346,15 +1573,20 @@ public void runStroke(Stroke stroke) {
             return false;
         }
         
-        // Get the effect output image (just the effect, not layered)
-        String outputPath = "project/" + projectId + "/stroke/" + strokeId + "_output.png";
-        PImage effectImage = app.loadImage(outputPath);
+        // Get the effect output image (just the effect, not layered). New
+        // strokes keep the full-resolution result in memory instead of writing
+        // a per-stroke output PNG. Legacy projects can still load output files.
+        PImage effectImage = strokeResultImages.get(strokeId);
+        if (effectImage == null) {
+            String outputPath = "project/" + projectId + "/stroke/" + strokeId + "_output.png";
+            effectImage = app.loadImage(outputPath);
+        }
         
         if (effectImage == null) {
-            System.err.println("Failed to load effect output image: " + outputPath);
+            System.err.println("No processed effect output is available for stroke: " + strokeId);
             JOptionPane.showMessageDialog(
                 null, 
-                "Failed to load effect output image.", 
+                "No processed effect output is available. Please re-run the effect.",
                 "Error", 
                 JOptionPane.ERROR_MESSAGE
             );
@@ -1409,16 +1641,6 @@ public void runStroke(Stroke stroke) {
         // Update project metadata to reflect the change
         app.getFileManager().updateProjectMetadata(projectId);
 
-        // IMPORTANT: Save the current state to disk
-        if (projectId != null) {
-            String projectPath = "project/" + projectId;
-            File projectDir = new File(projectPath);
-            if (projectDir.exists()) {
-                resultImage.save(projectPath + "/current.png");
-                System.out.println("Saved current state after applying effect");
-            }
-        }
-
         // Clear drawing paths (but don't save this as a project state)
         app.getCanvasManager().clearPaths();
         
@@ -1446,6 +1668,8 @@ public void runStroke(Stroke stroke) {
             
             // Remove from strokes list
             strokes.removeIf(stroke -> stroke.getId().equals(strokeId));
+            strokeInputImages.remove(strokeId);
+            strokeResultImages.remove(strokeId);
             
             // Delete stroke files
             String strokeDir = "project/" + projectId + "/stroke/";
@@ -1493,11 +1717,21 @@ public void runStroke(Stroke stroke) {
     public boolean hasStrokes() {
         return !strokes.isEmpty();
     }
+
+    public boolean hasInMemoryInput(String strokeId) {
+        return strokeInputImages.containsKey(strokeId);
+    }
+
+    public boolean hasInMemoryResult(String strokeId) {
+        return strokeResultImages.containsKey(strokeId);
+    }
     
     public void clearStrokes() {
         strokes.clear();
         currentStrokeIndex = -1;
         processingStrokes.clear();
+        strokeInputImages.clear();
+        strokeResultImages.clear();
     }
     
     /**

--- a/src/UIManager.java
+++ b/src/UIManager.java
@@ -573,11 +573,23 @@ public class UIManager {
         if (projectId != null) {
             // Input Image
             String inputPath = "project/" + projectId + "/stroke/" + stroke.getId() + "_input.png";
-            addImageWithOverlay(imagesPanel, inputPath, "Input", stroke);
+            if (new java.io.File(inputPath).exists()) {
+                addImageWithOverlay(imagesPanel, inputPath, "Input", stroke);
+            } else if (strokeManager.hasInMemoryInput(stroke.getId())) {
+                addImagePlaceholder(imagesPanel, "Input kept in memory", "Input");
+            } else {
+                addImagePlaceholder(imagesPanel, "Input will be captured when run", "Input");
+            }
 
             // Output Image
             String outputPath = "project/" + projectId + "/stroke/" + stroke.getId() + "_output.png";
-            addImageWithOverlay(imagesPanel, outputPath, "Output", null);
+            if (new java.io.File(outputPath).exists()) {
+                addImageWithOverlay(imagesPanel, outputPath, "Output", null);
+            } else if (strokeManager.hasInMemoryResult(stroke.getId())) {
+                addImagePlaceholder(imagesPanel, "Processed result kept in memory", "Output");
+            } else {
+                addImagePlaceholder(imagesPanel, "Not processed yet", "Output");
+            }
         }
         detailsPanel.add(imagesPanel);
         detailsPanel.add(Box.createVerticalStrut(10));

--- a/src/UIManager.java
+++ b/src/UIManager.java
@@ -573,20 +573,20 @@ public class UIManager {
         if (projectId != null) {
             // Input Image
             String inputPath = "project/" + projectId + "/stroke/" + stroke.getId() + "_input.png";
-            if (new java.io.File(inputPath).exists()) {
-                addImageWithOverlay(imagesPanel, inputPath, "Input", stroke);
+            if (QuantumBrush.appFile(inputPath).exists()) {
+                addImageWithOverlay(imagesPanel, QuantumBrush.appFile(inputPath).getAbsolutePath(), "Input", stroke);
             } else if (strokeManager.hasInMemoryInput(stroke.getId())) {
-                addImagePlaceholder(imagesPanel, "Input kept in memory", "Input");
+                addPImageWithOverlay(imagesPanel, strokeManager.getInMemoryInput(stroke.getId()), "Input", stroke);
             } else {
                 addImagePlaceholder(imagesPanel, "Input will be captured when run", "Input");
             }
 
             // Output Image
             String outputPath = "project/" + projectId + "/stroke/" + stroke.getId() + "_output.png";
-            if (new java.io.File(outputPath).exists()) {
-                addImageWithOverlay(imagesPanel, outputPath, "Output", null);
+            if (QuantumBrush.appFile(outputPath).exists()) {
+                addImageWithOverlay(imagesPanel, QuantumBrush.appFile(outputPath).getAbsolutePath(), "Output", null);
             } else if (strokeManager.hasInMemoryResult(stroke.getId())) {
-                addImagePlaceholder(imagesPanel, "Processed result kept in memory", "Output");
+                addPImageWithOverlay(imagesPanel, strokeManager.getInMemoryResult(stroke.getId()), "Output", null);
             } else {
                 addImagePlaceholder(imagesPanel, "Not processed yet", "Output");
             }
@@ -659,6 +659,47 @@ public class UIManager {
             String message = title.equals("Output") ? "Not processed yet" : "Image not found";
             addImagePlaceholder(container, message, title);
         }
+    }
+
+    private void addPImageWithOverlay(JPanel container, PImage image, String title, StrokeManager.Stroke stroke) {
+        if (image == null) {
+            addImagePlaceholder(container, "Image not available", title);
+            return;
+        }
+
+        BufferedImage bImg = pImageToBufferedImage(image);
+        if (stroke != null) {
+            bImg = createImageWithExactPathOverlay(bImg, stroke);
+        }
+
+        addBufferedImagePreview(container, bImg, title);
+    }
+
+    private BufferedImage pImageToBufferedImage(PImage image) {
+        BufferedImage bufferedImage = new BufferedImage(
+            image.width,
+            image.height,
+            BufferedImage.TYPE_INT_ARGB
+        );
+        image.loadPixels();
+        for (int y = 0; y < image.height; y++) {
+            for (int x = 0; x < image.width; x++) {
+                bufferedImage.setRGB(x, y, image.pixels[y * image.width + x]);
+            }
+        }
+        return bufferedImage;
+    }
+
+    private void addBufferedImagePreview(JPanel container, BufferedImage bImg, String title) {
+        int maxSize = 300;
+        float scale = Math.min(1, (float)maxSize / Math.max(bImg.getWidth(), bImg.getHeight()));
+        int displayWidth = (int)(bImg.getWidth() * scale);
+        int displayHeight = (int)(bImg.getHeight() * scale);
+
+        ImageIcon icon = new ImageIcon(bImg.getScaledInstance(displayWidth, displayHeight, Image.SCALE_SMOOTH));
+        JLabel label = new JLabel(icon);
+        label.setBorder(BorderFactory.createTitledBorder(title));
+        container.add(label);
     }
 
     private BufferedImage createImageWithExactPathOverlay(BufferedImage baseImage, StrokeManager.Stroke stroke) {

--- a/src/UIManager.java
+++ b/src/UIManager.java
@@ -708,6 +708,14 @@ public class UIManager {
         g2d.drawImage(baseImage, 0, 0, null);
         g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 
+        float scaleX = 1.0f;
+        float scaleY = 1.0f;
+        PImage currentImage = app.getCurrentImage();
+        if (currentImage != null && currentImage.width > 0 && currentImage.height > 0) {
+            scaleX = (float) baseImage.getWidth() / currentImage.width;
+            scaleY = (float) baseImage.getHeight() / currentImage.height;
+        }
+
         for (Path path : stroke.getPaths()) {
             // Draw path line
             g2d.setColor(Color.RED);
@@ -716,15 +724,22 @@ public class UIManager {
             for (int i = 0; i < points.size() - 1; i++) {
                 PVector p1 = points.get(i);
                 PVector p2 = points.get(i + 1);
-                g2d.drawLine((int)p1.x, (int)p1.y, (int)p2.x, (int)p2.y);
+                g2d.drawLine(
+                    Math.round(p1.x * scaleX),
+                    Math.round(p1.y * scaleY),
+                    Math.round(p2.x * scaleX),
+                    Math.round(p2.y * scaleY)
+                );
             }
             // Draw click point
             PVector clickPoint = path.getClickPoint();
             if (clickPoint != null) {
+                int clickX = Math.round(clickPoint.x * scaleX);
+                int clickY = Math.round(clickPoint.y * scaleY);
                 g2d.setColor(Color.YELLOW);
-                g2d.fillOval((int)clickPoint.x - 5, (int)clickPoint.y - 5, 10, 10);
+                g2d.fillOval(clickX - 5, clickY - 5, 10, 10);
                 g2d.setColor(Color.BLACK);
-                g2d.drawOval((int)clickPoint.x - 5, (int)clickPoint.y - 5, 10, 10);
+                g2d.drawOval(clickX - 5, clickY - 5, 10, 10);
             }
         }
         g2d.dispose();


### PR DESCRIPTION
﻿## Summary

This PR addresses #47 by replacing the per-stroke PNG file transport with an in-memory Java/Python effect pipeline.

Previously, each stroke wrote image files such as `_input.png` and `_output.png` to disk. With large images and repeated strokes, that can quickly make a project directory grow. This change keeps new stroke inputs and processed results in memory during the active session instead.

Java now sends the current canvas image to Python through stdin as PNG bytes using a small length-prefixed binary protocol. Python decodes the image in memory, runs the selected effect, and returns the processed PNG bytes through stdout. Logs and debug output stay on stderr, so they do not interfere with the binary response.

I also added `docs/in-memory-stroke-transport.md` with the technical workflow.

## Workflow

```mermaid
flowchart LR
    A["Java canvas PImage"] --> B["Encode PNG bytes in memory"]
    B --> C["stdin: JSON instructions + PNG bytes"]
    C --> D["Python apply_effect.py --stdio"]
    D --> E["Run brush/effect in memory"]
    E --> F["stdout: response JSON + result PNG bytes"]
    F --> G["Java decodes result into PImage"]
    G --> H["Apply result to canvas"]
```

## Changes

- Keep new stroke input images in memory instead of writing per-stroke input PNG files.
- Run effects through `apply_effect.py --stdio`.
- Send Java/Python payloads as length-prefixed binary messages.
- Store processed stroke results in memory for the active session.
- Keep legacy file-based output loading as a fallback for older projects.
- Reset reopened in-memory strokes to pending if their temporary result is no longer available.
- Update Stroke Manager previews so they do not expect per-stroke PNGs for the new transport.

## Validation

- Verified that the Java code compiles.
- Verified that `apply_effect.py` has no Python syntax errors.

## AI disclosure

I used AI assistance while developing this PR. I reviewed the generated changes and validation results before submitting.
