### PR TITLE
feat: add CI/CD pipeline for cross-platform standalone installers.

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -1,0 +1,45 @@
+name: Build QuantumBrush Installers
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          pip install -r requirements.txt
+
+      - name: Build Executable with PyInstaller
+        run: |
+          pyinstaller --noconfirm --onedir --windowed --name "QuantumBrush" main.py
+
+      - name: Upload Release Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: QuantumBrush-${{ runner.os }}
+          path: dist/QuantumBrush


### PR DESCRIPTION
Closes #49

**Description:**
This PR introduces a GitHub Actions CI/CD pipeline to automatically generate standalone executables for Windows, macOS, and Linux, eliminating the need for artists to use `install.sh` or terminal environments.

**Implementation Details:**
1. Created `.github/workflows/build-installers.yml` triggered on release publication.
2. Utilizes a build matrix to run jobs concurrently across `windows-latest`, `macos-latest`, and `ubuntu-latest`.
3. Automates the provisioning of Python 3.10 and Java 17 runtimes within the build runners.
4. Integrates `PyInstaller` to bundle the application, isolating the Python runtime and negating the need for end-user virtual environment management.
5. Uploads the finalized `dist/` directories as downloadable release artifacts.